### PR TITLE
Add IList CC and BCC Recipients

### DIFF
--- a/FluentEmail/Email.cs
+++ b/FluentEmail/Email.cs
@@ -131,6 +131,20 @@ namespace FluentEmail
         }
 
         /// <summary>
+        /// Adds all Carbon Copy in list to an email
+        /// </summary>
+        /// <param name="mailAddresses">List of recipients to CC</param>
+        /// <returns>Instance of the Email class</returns>
+        public Email CC(IList<MailAddress> mailAddresses)
+        {
+            foreach (var address in mailAddresses)
+            {
+                Message.CC.Add(address);
+            }
+            return this;
+        }
+        
+        /// <summary>
         /// Adds a blind carbon copy to the email
         /// </summary>
         /// <param name="emailAddress">Email address of bcc</param>
@@ -139,6 +153,20 @@ namespace FluentEmail
         public Email BCC(string emailAddress, string name = "")
         {
             Message.Bcc.Add(new MailAddress(emailAddress, name));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds all blind carbon copy in list to an email
+        /// </summary>
+        /// <param name="mailAddresses">List of recipients to BCC</param>
+        /// <returns>Instance of the Email class</returns>
+        public Email BCC(IList<MailAddress> mailAddresses)
+        {
+            foreach (var address in mailAddresses)
+            {
+                Message.Bcc.Add(address);
+            }
             return this;
         }
 

--- a/FluentEmailTests/FluentEmailTests.cs
+++ b/FluentEmailTests/FluentEmailTests.cs
@@ -82,6 +82,34 @@ namespace FluentEmailTests
         }
 
         [TestMethod]
+        public void Can_Add_Multiple_CCRecipients_From_List()
+        {
+            var emails = new List<MailAddress>();
+            emails.Add(new MailAddress("email1@email.com"));
+            emails.Add(new MailAddress("email2@email.com"));
+
+            var email = Email
+                        .From(fromEmail)
+                        .CC(emails);
+
+            Assert.AreEqual(2, email.Message.CC.Count);
+        }
+
+        [TestMethod]
+        public void Can_Add_Multiple_BCCRecipients_From_List()
+        {
+            var emails = new List<MailAddress>();
+            emails.Add(new MailAddress("email1@email.com"));
+            emails.Add(new MailAddress("email2@email.com"));
+
+            var email = Email
+                        .From(fromEmail)
+                        .BCC(emails);
+
+            Assert.AreEqual(2, email.Message.Bcc.Count);
+        }
+
+        [TestMethod]
         public void Is_Valid_With_Properties_Set()
         {
             var email = Email


### PR DESCRIPTION
This functionality is already in place for the 'To' list - this just adds it for CC and BCC as well, useful where an email has to be copied in to a few people.
