### PR TITLE
Added isHtml to ITemplateRenderer.Parse

### DIFF
--- a/FluentEmail/Email.cs
+++ b/FluentEmail/Email.cs
@@ -276,7 +276,7 @@ namespace FluentEmail
                 reader.Close();
             }
 
-            var result = _renderer.Parse(template, model);
+            var result = _renderer.Parse(template, model, isHtml);
             Message.Body = result;
             Message.IsBodyHtml = isHtml;
 
@@ -291,7 +291,7 @@ namespace FluentEmail
         /// <returns>Instance of the Email class</returns>
         public Email UsingTemplate<T>(string template, T model, bool isHtml = true)
         {
-            var result = _renderer.Parse(template, model);
+            var result = _renderer.Parse(template, model, isHtml);
             Message.Body = result;
             Message.IsBodyHtml = isHtml;
 

--- a/FluentEmail/ITemplateRenderer.cs
+++ b/FluentEmail/ITemplateRenderer.cs
@@ -7,6 +7,6 @@ namespace FluentEmail
 {
     public interface ITemplateRenderer
     {
-        string Parse<T>(string template, T model);
+        string Parse<T>(string template, T model, bool isHtml = true);
     }
 }

--- a/FluentEmail/RazorRenderer.cs
+++ b/FluentEmail/RazorRenderer.cs
@@ -14,7 +14,7 @@ namespace FluentEmail
             initializeRazorParser();
         }
 
-        public string Parse<T>(string template, T model)
+        public string Parse<T>(string template, T model, bool isHtml = true)
         {
             return Razor.Parse<T>(template, model);
         }


### PR DESCRIPTION
This option needs to pass down to custom template renderers to determine
whether or not to render out Html from the template.

For Razor, this is not much of an issue as the Html is defined within the template.  But for other renderers where the Html is generated (like Markdown), it needs to know whether to output Html or just keep it as plain text.
