### PR TITLE
Fixed bug with not passing down isHtml to renderer

### DIFF
--- a/FluentEmail/Email.cs
+++ b/FluentEmail/Email.cs
@@ -278,7 +278,7 @@ namespace FluentEmail
 
             CheckRenderer();
 
-            var result = _renderer.Parse(template, model);
+            var result = _renderer.Parse(template, model, isHtml);
             Message.Body = result;
             Message.IsBodyHtml = isHtml;
 
@@ -295,7 +295,7 @@ namespace FluentEmail
         {
             CheckRenderer();
 
-            var result = _renderer.Parse(template, model);
+            var result = _renderer.Parse(template, model, isHtml);
             Message.Body = result;
             Message.IsBodyHtml = isHtml;
 


### PR DESCRIPTION
UsingTemplate & UsingTemplateFromFile now correctly passes the isHtml parameter down to the renderer
