### PR TITLE
Fix for #64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,3 +241,4 @@ ModelManifest.xml
 
 # FAKE - F# Make
 .fake/
+.vs

--- a/.vs/restore.dg
+++ b/.vs/restore.dg
@@ -1,5 +1,0 @@
-#:C:\Data\Projects\FluentEmail-lukencode\src\Senders\FluentEmail.SendGrid\FluentEmail.SendGrid.xproj
-C:\Data\Projects\FluentEmail-lukencode\src\Senders\FluentEmail.SendGrid\FluentEmail.SendGrid.xproj|C:\Data\Projects\FluentEmail-lukencode\src\FluentEmail.Core\FluentEmail.Core.xproj
-#:C:\Data\Projects\FluentEmail-lukencode\test\FluentEmail.SendGrid.Tests\FluentEmail.SendGrid.Tests.xproj
-C:\Data\Projects\FluentEmail-lukencode\test\FluentEmail.SendGrid.Tests\FluentEmail.SendGrid.Tests.xproj|C:\Data\Projects\FluentEmail-lukencode\src\Senders\FluentEmail.SendGrid\FluentEmail.SendGrid.xproj
-C:\Data\Projects\FluentEmail-lukencode\src\Senders\FluentEmail.SendGrid\FluentEmail.SendGrid.xproj|C:\Data\Projects\FluentEmail-lukencode\src\FluentEmail.Core\FluentEmail.Core.xproj

--- a/src/Senders/FluentEmail.SendGrid/SendGridSender.cs
+++ b/src/Senders/FluentEmail.SendGrid/SendGridSender.cs
@@ -107,16 +107,11 @@ namespace FluentEmail.SendGrid
 
         private async Task<string> GetAttachmentBase64String(Stream stream)
         {
-            string converted;
-
-            using (var sr = new StreamReader(stream))
+            using (var ms = new MemoryStream())
             {
-                var s = await sr.ReadToEndAsync();
-                var stringBytes = Encoding.Unicode.GetBytes(s);
-                converted = Convert.ToBase64String(stringBytes);
+                await stream.CopyToAsync(ms);
+                return Convert.ToBase64String(ms.ToArray());
             }
-
-            return converted;
         }
 
         private bool IsHttpSuccess(int statusCode)


### PR DESCRIPTION
Changed to copy the string as binary content and then converting to base64. Tested with XLSX attachment successfully.

I also removed the .vs folder from GIT since it's only used by VS to keep track of your settings, it shouldn't be committed.