### PR TITLE
Changed FluentMail.Smtp to accept a method that returns an SmtpClient

### DIFF
--- a/test/FluentEmail.Smtp.Tests/FluentEmail.Smtp.Tests.csproj
+++ b/test/FluentEmail.Smtp.Tests/FluentEmail.Smtp.Tests.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170502-03" />
-    <PackageReference Include="NUnit" Version="3.6.1" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
   </ItemGroup>
 


### PR DESCRIPTION
This is in response to problems listed in #46.  I did three things here:
1. Changed the SmtpSender to accept a method that returns an SmtpClient, this allows you to create & dispose of a new email you send.  It also lets you define the default sender in startup initialization code
2. I removed the UseSsl property in favor of configuring the SmtpClient directly.
3. I updated the unit test to save emails to a directory.  This lets you test without an SMTP server running.

I needed the first change for a project I was working on, thought I'd offer it to the upstream project in hopes of making it easier to work with :)