### PR TITLE
SmtpSender forces it's SSL settings.

### DIFF
--- a/src/Senders/FluentEmail.Smtp/SmtpSender.cs
+++ b/src/Senders/FluentEmail.Smtp/SmtpSender.cs
@@ -24,7 +24,7 @@ namespace FluentEmail.Smtp
         public SmtpSender(SmtpClient client)
         {
             _client = client;
-            UseSsl = true;
+            UseSsl = client.EnableSsl;
         }
 
         public SendResponse Send(Email email, CancellationToken? token = null)

--- a/test/FluentEmail.Smtp.Tests/SmtpSenderTests.cs
+++ b/test/FluentEmail.Smtp.Tests/SmtpSenderTests.cs
@@ -69,5 +69,18 @@ namespace FluentEmail.Smtp.Tests
 
             Assert.IsTrue(response.Successful);
         }
+
+        [Test]
+        public void UseSslPropertyIsInSyncWithSmtpClient()
+        {
+            var client = new SmtpClient("localhost")
+            {
+                EnableSsl = false
+            };
+
+            var sender = new SmtpSender(client);
+
+            Assert.AreEqual(client.EnableSsl, sender.UseSsl);
+        }
     }
 }


### PR DESCRIPTION
While implementing mail functionality in my project I came across counterintuitive design. Basically, I tried to do the following:`
```
var client = new System.Net.Mail.SmtpClient("localhost", 25);
client.EnableSsl = false;

var sender = new SmtpSender(client);

Email.DefaultSender = sender;

```
Strangely, I still received ```System.Net.Mail.SmtpException: Server does not support secure connections``` exception. After investigating source code, I fount out that SmtpSender constructor ignores SmtpClient's property and forces ssl to be enabled. This pull request attempts to fix that.