### PR TITLE
Uses IFluentEmail interface instead of Email class in ISender interface

### DIFF
--- a/src/FluentEmail.Core/Defaults/SaveToDiskSender.cs
+++ b/src/FluentEmail.Core/Defaults/SaveToDiskSender.cs
@@ -18,19 +18,19 @@ namespace FluentEmail.Core.Defaults
             _directory = directory;
         }
 
-        public SendResponse Send(Email email, CancellationToken? token = null)
+        public SendResponse Send(IFluentEmail email, CancellationToken? token = null)
         {
             return SendAsync(email, token).GetAwaiter().GetResult();
         }
 
-        public async Task<SendResponse> SendAsync(Email email, CancellationToken? token = null)
+        public async Task<SendResponse> SendAsync(IFluentEmail email, CancellationToken? token = null)
         {
             var response = new SendResponse();
             await SaveEmailToDisk(email);
             return response;
         }
 
-        private async Task<bool> SaveEmailToDisk(Email email)
+        private async Task<bool> SaveEmailToDisk(IFluentEmail email)
         {
             var random = new Random();
             var filename = $"{_directory.TrimEnd('\\')}\\{DateTime.Now:yyyy-MM-dd_hh-mm-ss}_{random.Next(1000)}";

--- a/src/FluentEmail.Core/Interfaces/ISender.cs
+++ b/src/FluentEmail.Core/Interfaces/ISender.cs
@@ -6,7 +6,7 @@ namespace FluentEmail.Core.Interfaces
 {
     public interface ISender
     {
-        SendResponse Send(Email email, CancellationToken? token = null);
-        Task<SendResponse> SendAsync(Email email, CancellationToken? token = null);
+        SendResponse Send(IFluentEmail email, CancellationToken? token = null);
+        Task<SendResponse> SendAsync(IFluentEmail email, CancellationToken? token = null);
     }
 }

--- a/src/Senders/FluentEmail.Mailgun/MailgunSender.cs
+++ b/src/Senders/FluentEmail.Mailgun/MailgunSender.cs
@@ -25,12 +25,12 @@ namespace FluentEmail.Mailgun
             _apiKey = apiKey;
         }
 
-        public SendResponse Send(Email email, CancellationToken? token = null)
+        public SendResponse Send(IFluentEmail email, CancellationToken? token = null)
         {
             return SendAsync(email, token).GetAwaiter().GetResult();
         }
 
-        public async Task<SendResponse> SendAsync(Email email, CancellationToken? token = null)
+        public async Task<SendResponse> SendAsync(IFluentEmail email, CancellationToken? token = null)
         {
             var client = new HttpClient()
             {

--- a/src/Senders/FluentEmail.SendGrid/SendGridSender.cs
+++ b/src/Senders/FluentEmail.SendGrid/SendGridSender.cs
@@ -25,12 +25,12 @@ namespace FluentEmail.SendGrid
             _apiKey = apiKey;
             _sandBoxMode = sandBoxMode;
         }
-        public SendResponse Send(Email email, CancellationToken? token = null)
+        public SendResponse Send(IFluentEmail email, CancellationToken? token = null)
         {
             return SendAsync(email, token).GetAwaiter().GetResult();
         }
 
-        public async Task<SendResponse> SendAsync(Email email, CancellationToken? token = null)
+        public async Task<SendResponse> SendAsync(IFluentEmail email, CancellationToken? token = null)
         {
             var sendGridClient = new SendGridClient(_apiKey);
 

--- a/src/Senders/FluentEmail.Smtp/SmtpSender.cs
+++ b/src/Senders/FluentEmail.Smtp/SmtpSender.cs
@@ -27,12 +27,12 @@ namespace FluentEmail.Smtp
             UseSsl = true;
         }
 
-        public SendResponse Send(Email email, CancellationToken? token = null)
+        public SendResponse Send(IFluentEmail email, CancellationToken? token = null)
         {
             return SendAsync(email, token).GetAwaiter().GetResult();
         }
 
-        public async Task<SendResponse> SendAsync(Email email, CancellationToken? token = null)
+        public async Task<SendResponse> SendAsync(IFluentEmail email, CancellationToken? token = null)
         {
             var response = new SendResponse();
             _client.EnableSsl = UseSsl;
@@ -59,7 +59,7 @@ namespace FluentEmail.Smtp
             _client?.Dispose();
         }
 
-        private MailMessage CreateMailMessage(Email email)
+        private MailMessage CreateMailMessage(IFluentEmail email)
         {
             var data = email.Data;
             var message = new MailMessage


### PR DESCRIPTION
Actually, we can't do :
```csharp
var email = Email.From(...).Subject(...).Body(...).To(...);
new SmtpSender().SendAsync(email);
```
because the type of the email variable is IFluentEmail while Email class is expected in ISender interface.
So, I replaced Email by IFluentEmail in ISender interface.
