### PR TITLE
Try fix deadlock problem

### DIFF
--- a/src/Senders/FluentEmail.Smtp/SmtpSender.cs
+++ b/src/Senders/FluentEmail.Smtp/SmtpSender.cs
@@ -40,7 +40,7 @@ namespace FluentEmail.Smtp
 
         public SendResponse Send(IFluentEmail email, CancellationToken? token = null)
         {
-            return SendAsync(email, token).GetAwaiter().GetResult();
+            return Task.Run(() => SendAsync(email, token)).Result;
         }
 
         public async Task<SendResponse> SendAsync(IFluentEmail email, CancellationToken? token = null)


### PR DESCRIPTION
The deadlock was occured when send email via SmtpClient in sync method `Send` in ASP.NET MVC/WebAPI application. Use `Task.Run` instead of `GetAwaiter().GetResult()`.

Try resolve issue #104