### PR TITLE
Bugfix/mailgun async misuse

### DIFF
--- a/src/FluentEmail.Core/Email.cs
+++ b/src/FluentEmail.Core/Email.cs
@@ -474,6 +474,18 @@ namespace FluentEmail.Core
         }
 
         /// <summary>
+        /// Adds tag to the Email. This is currently only supported by the Mailgun provider. <see href="https://documentation.mailgun.com/en/latest/user_manual.html#tagging"/>
+        /// </summary>
+        /// <param name="tag">Tag name, max 128 characters, ASCII only</param>
+        /// <returns>Instance of the Email class</returns>
+        public IFluentEmail Tag(string tag)
+        {
+            Data.Tags.Add(tag);
+
+            return this;
+        }
+
+        /// <summary>
         /// Sends email synchronously
         /// </summary>
         /// <returns>Instance of the Email class</returns>

--- a/src/FluentEmail.Core/IFluentEmail.cs
+++ b/src/FluentEmail.Core/IFluentEmail.cs
@@ -227,5 +227,12 @@ namespace FluentEmail.Core
 	    /// <param name="model">Model for the template</param>
 	    /// <returns>Instance of the Email class</returns>
 	    IFluentEmail PlaintextAlternativeUsingTemplate<T>(string template, T model);
+
+	    /// <summary>
+	    /// Adds tag to the Email. This is currently only supported by the Mailgun provider. <see href="https://documentation.mailgun.com/en/latest/user_manual.html#tagging"/>
+	    /// </summary>
+	    /// <param name="tag">Tag name, max 128 characters, ASCII only</param>
+	    /// <returns>Instance of the Email class</returns>
+	    IFluentEmail Tag(string tag);
 	}
 }

--- a/src/FluentEmail.Core/Models/EmailData.cs
+++ b/src/FluentEmail.Core/Models/EmailData.cs
@@ -14,6 +14,7 @@ namespace FluentEmail.Core.Models
         public string Body { get; set; }
         public string PlaintextAlternativeBody { get; set; }
         public Priority Priority { get; set; }
+        public List<string> Tags { get; set; }
 
         public bool IsHtml { get; set; }
 
@@ -24,6 +25,7 @@ namespace FluentEmail.Core.Models
             BccAddresses = new List<Address>();
             ReplyToAddresses = new List<Address>();
             Attachments = new List<Attachment>();
+            Tags = new List<string>();
         }
     }
 }

--- a/src/Senders/FluentEmail.Mailgun/HttpHelpers/HttpClientHelpers.cs
+++ b/src/Senders/FluentEmail.Mailgun/HttpHelpers/HttpClientHelpers.cs
@@ -76,7 +76,7 @@ namespace FluentEmail.Mailgun.HttpHelpers
 
         public static async Task<ApiResponse<T>> PostMultipart<T>(this HttpClient client, string url, List<KeyValuePair<string, string>> parameters, List<HttpFile> files)
         {
-            var response = await client.PostAsync(url, HttpClientHelpers.GetMultipartFormDataContentBody(parameters, files));
+            var response = await client.PostAsync(url, HttpClientHelpers.GetMultipartFormDataContentBody(parameters, files)).ConfigureAwait(false);
             var qr = await QuickResponse<T>.FromMessage(response);
             return qr.ToApiResponse();
         }

--- a/src/Senders/FluentEmail.Mailgun/MailgunSender.cs
+++ b/src/Senders/FluentEmail.Mailgun/MailgunSender.cs
@@ -63,6 +63,11 @@ namespace FluentEmail.Mailgun
                 parameters.Add(new KeyValuePair<string, string>("text", email.Data.PlaintextAlternativeBody));
             }
 
+            email.Data.Tags.ForEach(x =>
+            {
+                parameters.Add(new KeyValuePair<string, string>("o:tag", x));
+            });
+
             var files = new List<HttpFile>();
             email.Data.Attachments.ForEach(x =>
             {

--- a/test/FluentEmail.Mailgun.Tests/FluentEmail.Mailgun.Tests.csproj
+++ b/test/FluentEmail.Mailgun.Tests/FluentEmail.Mailgun.Tests.csproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170502-03" />
-    <PackageReference Include="NUnit" Version="3.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/FluentEmail.Mailgun.Tests/MailgunSenderTests.cs
+++ b/test/FluentEmail.Mailgun.Tests/MailgunSenderTests.cs
@@ -36,6 +36,21 @@ namespace FluentEmail.Mailgun.Tests
         }
 
         [Test]
+        public async Task CanSendEmailWithTag()
+        {
+            var email = Email
+                .From(fromEmail)
+                .To(toEmail)
+                .Subject(subject)
+                .Body(body)
+                .Tag("test");
+
+            var response = await email.SendAsync();
+
+            Assert.IsTrue(response.Successful);
+        }
+
+        [Test]
         public async Task CanSendEmailWithAttachments()
         {
             var stream = new MemoryStream();


### PR DESCRIPTION
async await is not properly used in MailgunSender.

You should use ConfigureAwait(false) otherwise applications get locked up for example in IIS when calling MailgunSender.Send().

I fixed this issue in commit 79e5ac4.

More infos on this topic:
- https://stackoverflow.com/questions/10343632/httpclient-getasync-never-returns-when-using-await-async
- http://blog.stephencleary.com/2012/07/dont-block-on-async-code.html

Looking forward for a new nuget release containing this bugfix :)