### PR TITLE
Bug fix and some improvements.]

### DIFF
--- a/sample/SampleWeb/Controllers/HomeController.cs
+++ b/sample/SampleWeb/Controllers/HomeController.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using FluentEmail.Core;
 using Microsoft.AspNetCore.Mvc;
-using SampleWeb.Models;
 
 namespace SampleWeb.Controllers
 {

--- a/sample/SampleWeb/Models/ErrorViewModel.cs
+++ b/sample/SampleWeb/Models/ErrorViewModel.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace SampleWeb.Models
 {
     public class ErrorViewModel

--- a/sample/SampleWeb/Program.cs
+++ b/sample/SampleWeb/Program.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore;
+﻿using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 namespace SampleWeb
 {

--- a/sample/SampleWeb/Startup.cs
+++ b/sample/SampleWeb/Startup.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/FluentEmail.Core/Defaults/ReplaceRenderer.cs
+++ b/src/FluentEmail.Core/Defaults/ReplaceRenderer.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Threading.Tasks;
 using FluentEmail.Core.Interfaces;
 

--- a/src/FluentEmail.Core/Defaults/SaveToDiskSender.cs
+++ b/src/FluentEmail.Core/Defaults/SaveToDiskSender.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -33,7 +32,7 @@ namespace FluentEmail.Core.Defaults
         private async Task<bool> SaveEmailToDisk(IFluentEmail email)
         {
             var random = new Random();
-            var filename = $"{_directory.TrimEnd('\\')}\\{DateTime.Now:yyyy-MM-dd_hh-mm-ss}_{random.Next(1000)}";
+            var filename = $"{_directory.TrimEnd('\\')}\\{DateTime.Now:yyyy-MM-dd_HH-mm-ss}_{random.Next(1000)}";
 
             using (var sw = new StreamWriter(File.OpenWrite(filename)))
             {

--- a/src/FluentEmail.Core/FluentEmailFactory.cs
+++ b/src/FluentEmail.Core/FluentEmailFactory.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace FluentEmail.Core
 {

--- a/src/FluentEmail.Core/FluentEmailServiceCollectionExtensions.cs
+++ b/src/FluentEmail.Core/FluentEmailServiceCollectionExtensions.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using FluentEmail.Core;
 using FluentEmail.Core.Interfaces;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/FluentEmail.Core/IFluentEmail.cs
+++ b/src/FluentEmail.Core/IFluentEmail.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using System.Threading;

--- a/src/FluentEmail.Core/Models/Attachment.cs
+++ b/src/FluentEmail.Core/Models/Attachment.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.IO;
 
 namespace FluentEmail.Core.Models
 {

--- a/src/FluentEmail.Core/Models/SendResponse.cs
+++ b/src/FluentEmail.Core/Models/SendResponse.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace FluentEmail.Core.Models
 {

--- a/src/Renderers/FluentEmail.Razor/FluentEmailRazorBuilderExtensions.cs
+++ b/src/Renderers/FluentEmail.Razor/FluentEmailRazorBuilderExtensions.cs
@@ -1,9 +1,6 @@
 ﻿using FluentEmail.Core.Interfaces;
 using FluentEmail.Razor;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Renderers/FluentEmail.Razor/InMemoryRazorLightProject.cs
+++ b/src/Renderers/FluentEmail.Razor/InMemoryRazorLightProject.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using RazorLight.Razor;
 

--- a/src/Renderers/FluentEmail.Razor/RazorRenderer.cs
+++ b/src/Renderers/FluentEmail.Razor/RazorRenderer.cs
@@ -2,8 +2,6 @@
 using System.Threading.Tasks;
 using FluentEmail.Core.Interfaces;
 using RazorLight;
-using RazorLight.Extensions;
-using RazorLight.Razor;
 
 namespace FluentEmail.Razor
 {

--- a/src/Senders/FluentEmail.Mailgun/FluentEmailMailgunBuilderExtensions.cs
+++ b/src/Senders/FluentEmail.Mailgun/FluentEmailMailgunBuilderExtensions.cs
@@ -1,10 +1,6 @@
 ﻿using FluentEmail.Core.Interfaces;
 using FluentEmail.Mailgun;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using System;
-using System.Collections.Generic;
-using System.Net.Mail;
-using System.Text;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Senders/FluentEmail.Mailgun/HttpHelpers/HttpClientHelpers.cs
+++ b/src/Senders/FluentEmail.Mailgun/HttpHelpers/HttpClientHelpers.cs
@@ -138,9 +138,9 @@ namespace FluentEmail.Mailgun.HttpHelpers
                     });
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                Errors.Add(new ApiError()
+                Errors.Add(new ApiError
                 {
                     ErrorMessage = !string.IsNullOrEmpty(ResponseBody) ? ResponseBody : Message.StatusCode.ToString()
                 });
@@ -173,7 +173,7 @@ namespace FluentEmail.Mailgun.HttpHelpers
                 {
                     response.Data = JsonConvert.DeserializeObject<T>(response.ResponseBody);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     response.HandleFailedCall();
                 }

--- a/src/Senders/FluentEmail.Mailgun/HttpHelpers/HttpFile.cs
+++ b/src/Senders/FluentEmail.Mailgun/HttpHelpers/HttpFile.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
+﻿using System.IO;
 
 namespace FluentEmail.Mailgun.HttpHelpers
 {

--- a/src/Senders/FluentEmail.Mailgun/MailgunResponse.cs
+++ b/src/Senders/FluentEmail.Mailgun/MailgunResponse.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace FluentEmail.Mailgun
+﻿namespace FluentEmail.Mailgun
 {
     public class MailgunResponse
     {

--- a/src/Senders/FluentEmail.Mailgun/MailgunSender.cs
+++ b/src/Senders/FluentEmail.Mailgun/MailgunSender.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;

--- a/src/Senders/FluentEmail.SendGrid/FluentEmailSendGridBuilderExtensions.cs
+++ b/src/Senders/FluentEmail.SendGrid/FluentEmailSendGridBuilderExtensions.cs
@@ -1,10 +1,6 @@
 ﻿using FluentEmail.Core.Interfaces;
 using FluentEmail.SendGrid;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using System;
-using System.Collections.Generic;
-using System.Net.Mail;
-using System.Text;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/Senders/FluentEmail.SendGrid/SendGridSender.cs
+++ b/src/Senders/FluentEmail.SendGrid/SendGridSender.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentEmail.Core;

--- a/src/Senders/FluentEmail.Smtp/FluentEmailSmtpBuilderExtensions.cs
+++ b/src/Senders/FluentEmail.Smtp/FluentEmailSmtpBuilderExtensions.cs
@@ -2,9 +2,7 @@
 using FluentEmail.Smtp;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
-using System.Collections.Generic;
 using System.Net.Mail;
-using System.Text;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/test/FluentEmail.Core.Tests/AttachmentTests.cs
+++ b/test/FluentEmail.Core.Tests/AttachmentTests.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Threading.Tasks;
 using FluentEmail.Core.Models;
 using NUnit.Framework;
 

--- a/test/FluentEmail.Core.Tests/TemplateEmailTests.cs
+++ b/test/FluentEmail.Core.Tests/TemplateEmailTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Globalization;
 using System.IO;
 using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
 using FluentEmail.Core.Defaults;
 using FluentEmail.Core.Interfaces;

--- a/test/FluentEmail.Razor.Tests/RazorTests.cs
+++ b/test/FluentEmail.Razor.Tests/RazorTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using FluentEmail.Core;
+﻿using FluentEmail.Core;
 using NUnit.Framework;
 
 namespace FluentEmail.Razor.Tests

--- a/test/FluentEmail.SendGrid.Tests/SendGridSenderTests.cs
+++ b/test/FluentEmail.SendGrid.Tests/SendGridSenderTests.cs
@@ -1,25 +1,26 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using FluentEmail.Core;
-using FluentEmail.Core.Models;
 using NUnit.Framework;
+using Attachment = FluentEmail.Core.Models.Attachment;
 
 namespace FluentEmail.SendGrid.Tests
 {
     public class SendGridSenderTests
     {
-        const string apiKey = "";
-        const string toEmail = "fluentEmail@mailinator.com";
-        const string toName = "FluentEmail Mailinator";
-        const string fromEmail = "test@fluentmail.com";
-        const string fromName = "SendGridSender Test";
+        const string apiKey    = ""; // TODO: Put your API key here
+
+        const string toEmail   = "fluentEmail@mailinator.com";
+        const string toName    = "FluentEmail Mailinator"    ;
+        const string fromEmail = "test@fluentmail.com"       ;
+        const string fromName  = "SendGridSender Test"       ;
 
         [SetUp]
         public void SetUp()
         {
+            if (string.IsNullOrWhiteSpace(apiKey)) throw new ArgumentException("SendGrid Api Key need to be supplied");
+
             var sender = new SendGridSender(apiKey, true);
             Email.DefaultSender = sender;
         }

--- a/test/FluentEmail.Smtp.Tests/SmtpSenderTests.cs
+++ b/test/FluentEmail.Smtp.Tests/SmtpSenderTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 using System.Net.Mail;
 using System.Threading.Tasks;
 using FluentEmail.Core;
@@ -52,7 +49,7 @@ namespace FluentEmail.Smtp.Tests
         {
             var email = Email
                 .From(fromEmail)
-                .To(toEmail)                
+                .To(toEmail)
                 .Body("<h2>Test</h2>", true);
 
             var response = email.Send();
@@ -93,7 +90,21 @@ namespace FluentEmail.Smtp.Tests
         }
 
         [Test]
-        public async Task CanSendHtmlAndPlaintextTogether()
+        public async Task CanSendAsyncHtmlAndPlaintextTogether()
+        {
+            var email = Email
+                .From(fromEmail)
+                .To(toEmail)
+                .Body("<h2>Test</h2><p>some body text</p>", true)
+                .PlaintextAlternativeBody("Test - Some body text");
+
+            var response = await email.SendAsync();
+
+            Assert.IsTrue(response.Successful);
+        }
+
+        [Test]
+        public void CanSendHtmlAndPlaintextTogether()
         {
             var email = Email
                 .From(fromEmail)


### PR DESCRIPTION
Hey Luke, Some improvements, and a small bug fix.

the `SaveToDisk` used the wrong time formatter. using `yyy-MM-dd_hh-mm-ss` instead of `yyy-MM-dd_HH-mm-ss` means that sending one email at 4am and 4pm will both end up with "04" as hour.

It should be easiest to review per commit, since you'll have 3 simple small ones (as per commit message), and then a "big" commit which is only removing statements.

P.S.
There's an extra catchya hidden in the code though . You're using RazorLight alpha 3. 
Trying to send anything with a template from a .Net core 2.1+ explodes horribly and sadly.
As a workaround, you can use the simple replace engine.
Maybe worth writing something in the readme to save some unsuspecting users the puzzlement if they hit it? 

Cheers for your work.
