### PR TITLE
Fixes issue with RazorLight dependency not working with lastest .net core

### DIFF
--- a/src/Renderers/FluentEmail.Razor/FluentEmail.Razor.csproj
+++ b/src/Renderers/FluentEmail.Razor/FluentEmail.Razor.csproj
@@ -13,9 +13,13 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Version>2.5.0</Version>
   </PropertyGroup>
+  
+  <PropertyGroup>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
+  </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RazorLight" Version="2.0.0-alpha3" />
+    <PackageReference Include="RazorLight" Version="2.0.0-beta1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes issue: https://github.com/lukencode/FluentEmail/issues/123

I updated the RazorLight package and got a different error.  Solution was to add the property group isolated as per: https://github.com/toddams/RazorLight/issues/127