### PR TITLE
Added ContentID to SMTP to be able to inline image in the e-mail body.

### DIFF
--- a/src/FluentEmail.Core/Models/Attachment.cs
+++ b/src/FluentEmail.Core/Models/Attachment.cs
@@ -11,5 +11,6 @@ namespace FluentEmail.Core.Models
         public string Filename { get; set; }
         public Stream Data { get; set; }
         public string ContentType { get; set; }
+        public string ContentId { get; set; }
     }
 }

--- a/src/Senders/FluentEmail.Smtp/SmtpSender.cs
+++ b/src/Senders/FluentEmail.Smtp/SmtpSender.cs
@@ -141,7 +141,11 @@ namespace FluentEmail.Smtp
 
             data.Attachments.ForEach(x =>
             {
-                message.Attachments.Add(new System.Net.Mail.Attachment(x.Data, x.Filename, x.ContentType));
+                System.Net.Mail.Attachment a = new System.Net.Mail.Attachment(x.Data, x.Filename, x.ContentType);
+
+                a.ContentId = x.ContentId;
+
+                message.Attachments.Add(a);
             });
 
             return message;


### PR DESCRIPTION
For more info: https://stackoverflow.com/a/50564917/114029

This code made the image attachment show inline with SMTP and solves this issue:

https://github.com/lukencode/FluentEmail/issues/101