### PR TITLE
added functionality to add custom headers to mail

### DIFF
--- a/src/FluentEmail.Core/Defaults/SaveToDiskSender.cs
+++ b/src/FluentEmail.Core/Defaults/SaveToDiskSender.cs
@@ -42,6 +42,10 @@ namespace FluentEmail.Core.Defaults
                 sw.WriteLine($"Bcc: {string.Join(",", email.Data.BccAddresses.Select(x => $"{x.Name} <{x.EmailAddress}>"))}");
                 sw.WriteLine($"ReplyTo: {string.Join(",", email.Data.ReplyToAddresses.Select(x => $"{x.Name} <{x.EmailAddress}>"))}");
                 sw.WriteLine($"Subject: {email.Data.Subject}");
+                foreach (var dataHeader in email.Data.Headers)
+                {
+                    sw.WriteLine($"{dataHeader.Key}:{dataHeader.Value}");
+                }
                 sw.WriteLine();
                 await sw.WriteAsync(email.Data.Body);
             }

--- a/src/FluentEmail.Core/Email.cs
+++ b/src/FluentEmail.Core/Email.cs
@@ -485,6 +485,13 @@ namespace FluentEmail.Core
             return this;
         }
 
+        public IFluentEmail Header(string header, string body)
+        {
+            Data.Headers.Add(header, body);
+
+            return this;
+        }
+
         /// <summary>
         /// Sends email synchronously
         /// </summary>

--- a/src/FluentEmail.Core/IFluentEmail.cs
+++ b/src/FluentEmail.Core/IFluentEmail.cs
@@ -233,5 +233,13 @@ namespace FluentEmail.Core
 	    /// <param name="tag">Tag name, max 128 characters, ASCII only</param>
 	    /// <returns>Instance of the Email class</returns>
 	    IFluentEmail Tag(string tag);
-	}
+
+	    /// <summary>
+	    /// Adds header to the Email.
+	    /// </summary>
+	    /// <param name="header">Header name, only printable ASCII allowed.</param>
+	    /// <param name="body">value of the header</param>
+	    /// <returns>Instance of the Email class</returns>
+	    IFluentEmail Header(string header, string body);
+    }
 }

--- a/src/FluentEmail.Core/Models/EmailData.cs
+++ b/src/FluentEmail.Core/Models/EmailData.cs
@@ -17,6 +17,7 @@ namespace FluentEmail.Core.Models
         public List<string> Tags { get; set; }
 
         public bool IsHtml { get; set; }
+        public Dictionary<string, string> Headers { get; set; }
 
         public EmailData()
         {
@@ -26,6 +27,7 @@ namespace FluentEmail.Core.Models
             ReplyToAddresses = new List<Address>();
             Attachments = new List<Attachment>();
             Tags = new List<string>();
+            Headers = new Dictionary<string, string>();
         }
     }
 }

--- a/src/Senders/FluentEmail.Mailgun/MailgunSender.cs
+++ b/src/Senders/FluentEmail.Mailgun/MailgunSender.cs
@@ -80,6 +80,17 @@ namespace FluentEmail.Mailgun
                 parameters.Add(new KeyValuePair<string, string>("o:tag", x));
             });
 
+            foreach (var emailHeader in email.Data.Headers)
+            {
+                var key = emailHeader.Key;
+                if (!key.StartsWith("h:"))
+                {
+                    key = "h:" + emailHeader.Key;
+                }
+
+                parameters.Add(new KeyValuePair<string, string>(key, emailHeader.Value));   
+            }
+
             var files = new List<HttpFile>();
             email.Data.Attachments.ForEach(x =>
             {

--- a/src/Senders/FluentEmail.SendGrid/SendGridSender.cs
+++ b/src/Senders/FluentEmail.SendGrid/SendGridSender.cs
@@ -47,6 +47,11 @@ namespace FluentEmail.SendGrid
 
             mailMessage.SetSubject(email.Data.Subject);
 
+            if (email.Data.Headers.Any())
+            {
+                mailMessage.AddHeaders(email.Data.Headers);
+            }
+
             if (email.Data.IsHtml)
             {
                 mailMessage.HtmlContent = email.Data.Body;

--- a/src/Senders/FluentEmail.Smtp/SmtpSender.cs
+++ b/src/Senders/FluentEmail.Smtp/SmtpSender.cs
@@ -2,6 +2,7 @@ using FluentEmail.Core;
 using FluentEmail.Core.Interfaces;
 using FluentEmail.Core.Models;
 using System;
+using System.Collections.Specialized;
 using System.Net.Mail;
 using System.Text;
 using System.Threading;
@@ -104,6 +105,11 @@ namespace FluentEmail.Smtp
                     SubjectEncoding = Encoding.UTF8,
                     From = new MailAddress(data.FromAddress.EmailAddress, data.FromAddress.Name)
                 };
+            }
+
+            foreach (var header in data.Headers)
+            {
+                message.Headers.Add(header.Key, header.Value);
             }
 
             data.ToAddresses.ForEach(x =>

--- a/test/FluentEmail.Mailgun.Tests/MailgunSenderTests.cs
+++ b/test/FluentEmail.Mailgun.Tests/MailgunSenderTests.cs
@@ -4,6 +4,7 @@ using FluentEmail.Core;
 using FluentEmail.Core.Models;
 using NUnit.Framework;
 using System.Reflection;
+using Newtonsoft.Json;
 
 namespace FluentEmail.Mailgun.Tests
 {
@@ -44,6 +45,21 @@ namespace FluentEmail.Mailgun.Tests
                 .Subject(subject)
                 .Body(body)
                 .Tag("test");
+
+            var response = await email.SendAsync();
+
+            Assert.IsTrue(response.Successful);
+        }
+
+        [Test]
+        public async Task CanSendEmailWithVariables()
+        {
+            var email = Email
+                .From(fromEmail)
+                .To(toEmail)
+                .Subject(subject)
+                .Body(body)
+                .Header("X-Mailgun-Variables", JsonConvert.SerializeObject(new Variable { Var1 = "Test"}));
 
             var response = await email.SendAsync();
 
@@ -106,6 +122,11 @@ namespace FluentEmail.Mailgun.Tests
             var response = await email.SendAsync();
 
             Assert.IsTrue(response.Successful);
+        }
+
+        class Variable
+        {
+            public string Var1 { get; set; }
         }
     }
 }


### PR DESCRIPTION
To use advanced features, like variables of mailgun. Custom Headers are really useful.

I have implemented now a way to add headers to a mail and also added it to the other mail senders.
For send grid and smtp I am not able to test it but it should work.