### PR TITLE
Added optional AttachmentName parameter to AttachFromFilename().

### DIFF
--- a/src/FluentEmail.Core/Email.cs
+++ b/src/FluentEmail.Core/Email.cs
@@ -460,13 +460,13 @@ namespace FluentEmail.Core
             return this;
         }
 
-        public IFluentEmail AttachFromFilename(string filename, string contentType = null)
+        public IFluentEmail AttachFromFilename(string filename,  string contentType = null, string attachmentName = null)
         {
             var stream = File.OpenRead(filename);
             Attach(new Attachment()
             {
                 Data = stream,
-                Filename = filename,
+                Filename = attachmentName ?? filename,
                 ContentType = contentType
             });
 

--- a/src/FluentEmail.Core/IFluentEmail.cs
+++ b/src/FluentEmail.Core/IFluentEmail.cs
@@ -183,7 +183,7 @@ namespace FluentEmail.Core
         /// <returns></returns>
 	    Task<SendResponse> SendAsync(CancellationToken? token = null);
 
-	    IFluentEmail AttachFromFilename(string filename, string contentType = null);
+	    IFluentEmail AttachFromFilename(string filename,  string contentType = null, string attachmentName = null);
 
 	    /// <summary>
 	    /// Adds a Plaintext alternative Body to the Email. Used in conjunction with an HTML email,

--- a/test/FluentEmail.Core.Tests/AttachmentTests.cs
+++ b/test/FluentEmail.Core.Tests/AttachmentTests.cs
@@ -45,5 +45,18 @@ namespace FluentEmail.Core.Tests
 
             Assert.AreEqual(20, email.Data.Attachments.First().Data.Length);
         }
+
+        [Test]
+        public void Attachment_from_filename_AttachmentName_Is_set()
+        {
+            var attachmentName = "attachment.txt";
+            var email = Email.From(fromEmail)
+                .To(toEmail)
+                .Subject(subject)
+                .AttachFromFilename($"{Directory.GetCurrentDirectory()}/Test.txt", "text/plain", attachmentName);
+
+            Assert.AreEqual(20, email.Data.Attachments.First().Data.Length);
+            Assert.AreEqual(attachmentName, email.Data.Attachments.First().Filename);
+        }
     }
 }


### PR DESCRIPTION
Currently when using AttachFromFilename (at least in my use-case), the name of attachment will be the full path of the file which may or may not be desired.  This new parameter will allow the user to optionally specify the name of the attachment.

This is my first pull request and my first contribution to an open source project, so I'm totally open to feedback if something could be done better.