### PR TITLE
Adding SSL and login support for dependency injection extension method

### DIFF
--- a/src/Senders/FluentEmail.Smtp/FluentEmailSmtpBuilderExtensions.cs
+++ b/src/Senders/FluentEmail.Smtp/FluentEmailSmtpBuilderExtensions.cs
@@ -16,6 +16,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static FluentEmailServicesBuilder AddSmtpSender(this FluentEmailServicesBuilder builder, string host, int port) => AddSmtpSender(builder, new SmtpClient(host, port));
 
+        public static FluentEmailServicesBuilder AddSmtpSender(this FluentEmailServicesBuilder builder, string host, int port, string username, string password) => AddSmtpSender(builder,
+             new SmtpClient(host, port) { EnableSsl = true, Credentials = new NetworkCredential (username, password) });
+        
         public static FluentEmailServicesBuilder AddSmtpSender(this FluentEmailServicesBuilder builder, Func<SmtpClient> clientFactory)
         {
             builder.Services.TryAdd(ServiceDescriptor.Scoped<ISender>(x => new SmtpSender(clientFactory)));


### PR DESCRIPTION
Quick and dirty, but also an effective way to get login support for the SMTP client. Tested working.

Before a nuget release someone could write tests and include login features it in the Core.Email object for non-DI users.