### PR TITLE
inject RazorLightEngine when create RazorRenderer

### DIFF
--- a/src/Renderers/FluentEmail.Razor/FluentEmailRazorBuilderExtensions.cs
+++ b/src/Renderers/FluentEmail.Razor/FluentEmailRazorBuilderExtensions.cs
@@ -1,53 +1,57 @@
-﻿using System;
-using FluentEmail.Core.Interfaces;
+﻿using FluentEmail.Core.Interfaces;
 using FluentEmail.Razor;
-using Microsoft.Extensions.DependencyInjection.Extensions;
+using RazorLight.Extensions;
 using RazorLight.Razor;
+using System;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
-	public static class FluentEmailRazorBuilderExtensions
+    public static class FluentEmailRazorBuilderExtensions
     {
-	    public static FluentEmailServicesBuilder AddRazorRenderer(this FluentEmailServicesBuilder builder)
-	    {
-		    builder.Services.TryAdd(ServiceDescriptor.Singleton<ITemplateRenderer, RazorRenderer>(sp => new RazorRenderer()));
-		    return builder;
-	    }
-
-	    /// <summary>
-	    /// Add razor renderer with project views and layouts
-	    /// </summary>
-	    /// <param name="builder"></param>
-	    /// <param name="templateRootFolder"></param>
-	    /// <returns></returns>
-	    public static FluentEmailServicesBuilder AddRazorRenderer(this FluentEmailServicesBuilder builder, string templateRootFolder)
+        public static FluentEmailServicesBuilder AddRazorRenderer(this FluentEmailServicesBuilder builder)
         {
-            builder.Services.TryAdd(ServiceDescriptor.Singleton<ITemplateRenderer, RazorRenderer>(sp => new RazorRenderer(templateRootFolder)));
+            builder.Services.AddRazorLight(() => RazorLightEngineFactory.Create());
+            builder.Services.AddSingleton<ITemplateRenderer, RazorRenderer>();
             return builder;
         }
 
-		/// <summary>
-		/// Add razor renderer with embedded views and layouts
-		/// </summary>
-		/// <param name="builder"></param>
-		/// <param name="embeddedResourceRootType"></param>
-		/// <returns></returns>
-	    public static FluentEmailServicesBuilder AddRazorRenderer(this FluentEmailServicesBuilder builder, Type embeddedResourceRootType)
-	    {
-		    builder.Services.TryAdd(ServiceDescriptor.Singleton<ITemplateRenderer, RazorRenderer>(sp => new RazorRenderer( embeddedResourceRootType)));
-		    return builder;
-	    }
-	    
-	    /// <summary>
-	    /// Add razor renderer with a RazorLightProject to support views and layouts
-	    /// </summary>
-	    /// <param name="builder"></param>
-	    /// <param name="razorLightProject"></param>
-	    /// <returns></returns>
-	    public static FluentEmailServicesBuilder AddRazorRenderer(this FluentEmailServicesBuilder builder, RazorLightProject razorLightProject)
-	    {
-		    builder.Services.TryAdd(ServiceDescriptor.Singleton<ITemplateRenderer, RazorRenderer>(sp => new RazorRenderer(razorLightProject)));
-		    return builder;
-	    }
+        /// <summary>
+        /// Add razor renderer with project views and layouts
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="templateRootFolder"></param>
+        /// <returns></returns>
+        public static FluentEmailServicesBuilder AddRazorRenderer(this FluentEmailServicesBuilder builder, string templateRootFolder)
+        {
+            builder.Services.AddRazorLight(() => RazorLightEngineFactory.Create(templateRootFolder));
+            builder.Services.AddSingleton<ITemplateRenderer, RazorRenderer>();
+            return builder;
+        }
+
+        /// <summary>
+        /// Add razor renderer with embedded views and layouts
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="embeddedResourceRootType"></param>
+        /// <returns></returns>
+        public static FluentEmailServicesBuilder AddRazorRenderer(this FluentEmailServicesBuilder builder, Type embeddedResourceRootType)
+        {
+            builder.Services.AddRazorLight(() => RazorLightEngineFactory.Create(embeddedResourceRootType));
+            builder.Services.AddSingleton<ITemplateRenderer, RazorRenderer>();
+            return builder;
+        }
+
+        /// <summary>
+        /// Add razor renderer with a RazorLightProject to support views and layouts
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="razorLightProject"></param>
+        /// <returns></returns>
+        public static FluentEmailServicesBuilder AddRazorRenderer(this FluentEmailServicesBuilder builder, RazorLightProject razorLightProject)
+        {
+            builder.Services.AddRazorLight(() => RazorLightEngineFactory.Create(razorLightProject));
+            builder.Services.AddSingleton<ITemplateRenderer, RazorRenderer>();
+            return builder;
+        }
     }
 }

--- a/src/Renderers/FluentEmail.Razor/RazorLightEngineFactory.cs
+++ b/src/Renderers/FluentEmail.Razor/RazorLightEngineFactory.cs
@@ -1,0 +1,42 @@
+﻿using RazorLight;
+using RazorLight.Razor;
+using System;
+using System.IO;
+
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("FluentEmail.Razor.Tests")]
+namespace FluentEmail.Razor
+{
+    internal static class RazorLightEngineFactory
+    {
+        public static IRazorLightEngine Create()
+        {
+            return new RazorLightEngineBuilder()
+                .UseMemoryCachingProvider()
+                .Build();
+        }
+
+        public static IRazorLightEngine Create(string root)
+        {
+            return new RazorLightEngineBuilder()
+                .UseFilesystemProject(root ?? Directory.GetCurrentDirectory())
+                .UseMemoryCachingProvider()
+                .Build();
+        }
+
+        public static IRazorLightEngine Create(RazorLightProject project)
+        {
+            return new RazorLightEngineBuilder()
+                .UseProject(project)
+                .UseMemoryCachingProvider()
+                .Build();
+        }
+
+        public static IRazorLightEngine Create(Type embeddedResRootType)
+        {
+            return new RazorLightEngineBuilder()
+                .UseEmbeddedResourcesProject(embeddedResRootType)
+                .UseMemoryCachingProvider()
+                .Build();
+        }
+    }
+}

--- a/src/Renderers/FluentEmail.Razor/RazorRenderer.cs
+++ b/src/Renderers/FluentEmail.Razor/RazorRenderer.cs
@@ -1,50 +1,21 @@
 ﻿using FluentEmail.Core.Interfaces;
 using RazorLight;
-using RazorLight.Razor;
-using System;
-using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace FluentEmail.Razor
 {
-	public class RazorRenderer : ITemplateRenderer
+    public class RazorRenderer : ITemplateRenderer
     {
-	    private readonly RazorLightEngine _engine;
+	    private readonly IRazorLightEngine _engine;
 
-	    public RazorRenderer()
-	    {
-		    _engine = new RazorLightEngineBuilder()
-			    .UseMemoryCachingProvider()
-			    .Build();      
-	    }
+        public RazorRenderer(IRazorLightEngine engine)
+        {
+            _engine = engine;
+        }
 
-	    public RazorRenderer(string root)
-	    {
-		    _engine = new RazorLightEngineBuilder()
-			    .UseFilesystemProject(root ?? Directory.GetCurrentDirectory())
-			    .UseMemoryCachingProvider()
-			    .Build();      
-	    }
-
-	    public RazorRenderer(RazorLightProject project)
-	    {
-		    _engine = new RazorLightEngineBuilder()
-			    .UseProject(project)
-				.UseMemoryCachingProvider()
-			    .Build();      
-	    }
-
-	    public RazorRenderer(Type embeddedResRootType)
-	    {
-		    _engine = new RazorLightEngineBuilder()
-			    .UseEmbeddedResourcesProject(embeddedResRootType)
-			    .UseMemoryCachingProvider()
-			    .Build();      
-	    }
-
-	    public async Task<string> ParseAsync<T>(string template, T model, bool isHtml = true)
+        public async Task<string> ParseAsync<T>(string template, T model, bool isHtml = true)
 	    {            
 		    dynamic viewBag = (model as IViewBagModel)?.ViewBag;
 		    return await _engine.CompileRenderAsync<T>(GetHashString(template), template, model, viewBag);

--- a/test/FluentEmail.Razor.Tests/RazorTests.cs
+++ b/test/FluentEmail.Razor.Tests/RazorTests.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using System.Dynamic;
 using System.IO;
+using FluentEmail.Razor;
 
 namespace FluentEmail.Razor.Tests
 {
@@ -14,7 +15,8 @@ namespace FluentEmail.Razor.Tests
         [SetUp]
         public void SetUp()
         {
-            Email.DefaultRenderer = new RazorRenderer();
+            var engine = RazorLightEngineFactory.Create();
+            Email.DefaultRenderer = new RazorRenderer(engine);
         }
 
         [Test]
@@ -112,7 +114,8 @@ namespace FluentEmail.Razor.Tests
 	    public void Should_be_able_to_use_project_layout_with_viewbag()
 	    {
 		    var projectRoot = Directory.GetCurrentDirectory();
-		    Email.DefaultRenderer = new RazorRenderer(projectRoot);
+            var engine = RazorLightEngineFactory.Create(projectRoot);
+            Email.DefaultRenderer = new RazorRenderer(engine);
 
 		    string template = @"
 @{
@@ -133,8 +136,8 @@ sup @Model.Name here is a list @foreach(var i in Model.Numbers) { @i }";
 	    [Test]
 	    public void Should_be_able_to_use_embedded_layout_with_viewbag()
 	    {
-		    
-		    Email.DefaultRenderer = new RazorRenderer(typeof(RazorTests));
+            var engine = RazorLightEngineFactory.Create(typeof(RazorTests));
+            Email.DefaultRenderer = new RazorRenderer(engine);
 		    string template = @"
 @{
 	Layout = ""_EmbeddedLayout.cshtml"";


### PR DESCRIPTION
@lukencode 
I move logic that create `IRazorLightEngine`  to a factory class, and inject that by method `AddRazorLight()`.  
It's necessary for some feature in the library `RazorLight`.   e.g: `@inject`.