### PR TITLE
Sendgrid service lifetime now singleton

### DIFF
--- a/src/Senders/FluentEmail.SendGrid/FluentEmailSendGridBuilderExtensions.cs
+++ b/src/Senders/FluentEmail.SendGrid/FluentEmailSendGridBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static FluentEmailServicesBuilder AddSendGridSender(this FluentEmailServicesBuilder builder, string apiKey, bool sandBoxMode = false)
         {
-            builder.Services.TryAdd(ServiceDescriptor.Scoped<ISender>(x => new SendGridSender(apiKey, sandBoxMode)));
+            builder.Services.TryAdd(ServiceDescriptor.Singleton<ISender>(x => new SendGridSender(apiKey, sandBoxMode)));
             return builder;
         }
     }


### PR DESCRIPTION
I've got error with Scoped service lifetime with my .NET core application.

`Cannot resolve scoped service 'FluentEmail.Core.Interfaces.ISender' from root provider`

Changed to Singleton and tested with that and it worked. Also I was not able to send multiple emails, only one per application lifetime.