### PR TITLE
Added ability to configure socket options while connecting via MailKit (e.g. for Office 365 SMTP service)

### DIFF
--- a/src/Senders/FluentEmail.MailKit/MailKitSender.cs
+++ b/src/Senders/FluentEmail.MailKit/MailKitSender.cs
@@ -53,12 +53,23 @@ namespace FluentEmail.MailKitSmtp
 
                 using (var client = new SmtpClient())
                 {
-                    client.Connect(
-                        _smtpClientOptions.Server,
-                        _smtpClientOptions.Port,
-                        _smtpClientOptions.UseSsl, 
-                        token.GetValueOrDefault());
-                        
+                    if (_smtpClientOptions.SocketOptions.HasValue)
+                    {
+                        client.Connect(
+                            _smtpClientOptions.Server,
+                            _smtpClientOptions.Port,
+                            _smtpClientOptions.SocketOptions.Value,
+                            token.GetValueOrDefault());
+                    }
+                    else
+                    {
+                        client.Connect(
+                            _smtpClientOptions.Server,
+                            _smtpClientOptions.Port,
+                            _smtpClientOptions.UseSsl,
+                            token.GetValueOrDefault());
+                    }
+
                     // Note: only needed if the SMTP server requires authentication
                     if (_smtpClientOptions.RequiresAuthentication)
                     {
@@ -104,11 +115,22 @@ namespace FluentEmail.MailKitSmtp
 
                 using (var client = new SmtpClient())
                 {
-                    await client.ConnectAsync(
-                        _smtpClientOptions.Server,
-                        _smtpClientOptions.Port,
-                        _smtpClientOptions.UseSsl,
-                        token.GetValueOrDefault());
+                    if (_smtpClientOptions.SocketOptions.HasValue)
+                    {
+                        client.Connect(
+                            _smtpClientOptions.Server,
+                            _smtpClientOptions.Port,
+                            _smtpClientOptions.SocketOptions.Value,
+                            token.GetValueOrDefault());
+                    }
+                    else
+                    {
+                        client.Connect(
+                            _smtpClientOptions.Server,
+                            _smtpClientOptions.Port,
+                            _smtpClientOptions.UseSsl,
+                            token.GetValueOrDefault());
+                    }
 
                     // Note: only needed if the SMTP server requires authentication
                     if (_smtpClientOptions.RequiresAuthentication)

--- a/src/Senders/FluentEmail.MailKit/SmtpClientOptions.cs
+++ b/src/Senders/FluentEmail.MailKit/SmtpClientOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using MailKit.Security;
 
 namespace FluentEmail.MailKitSmtp
 {
@@ -13,5 +13,6 @@ namespace FluentEmail.MailKitSmtp
         public string PreferredEncoding { get; set; } = string.Empty;
         public bool UsePickupDirectory { get; set; } = false;
         public string MailPickupDirectory { get; set; } = string.Empty;
+        public SecureSocketOptions? SocketOptions { get; set; }
     }
 }


### PR DESCRIPTION
This setting is needed, if you want to connect to the Office 365 SMTP service. The existing `UseSSL` flag does not work in this case.

```csharp
new SmtpClientOptions
{
    Server = emailSettings.Host,
    Port = emailSettings.Port,
    User = emailSettings.Username,
    Password = emailSettings.Password,
    SocketOptions = SecureSocketOptions.StartTls,
    RequiresAuthentication = true
};
```