### PR TITLE
Fix AddSmtpSender extension methods to property add service

### DIFF
--- a/src/Senders/FluentEmail.Smtp/FluentEmailSmtpBuilderExtensions.cs
+++ b/src/Senders/FluentEmail.Smtp/FluentEmailSmtpBuilderExtensions.cs
@@ -11,14 +11,14 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static FluentEmailServicesBuilder AddSmtpSender(this FluentEmailServicesBuilder builder, SmtpClient smtpClient)
         {
-            builder.Services.TryAdd(ServiceDescriptor.Scoped<ISender>(x => new SmtpSender(smtpClient)));
+            builder.Services.TryAdd(ServiceDescriptor.Singleton<ISender>(x => new SmtpSender(smtpClient)));
             return builder;
         }
 
-        public static FluentEmailServicesBuilder AddSmtpSender(this FluentEmailServicesBuilder builder, string host, int port) => AddSmtpSender(builder, new SmtpClient(host, port));
+        public static FluentEmailServicesBuilder AddSmtpSender(this FluentEmailServicesBuilder builder, string host, int port) => AddSmtpSender(builder, () => new SmtpClient(host, port));
 
         public static FluentEmailServicesBuilder AddSmtpSender(this FluentEmailServicesBuilder builder, string host, int port, string username, string password) => AddSmtpSender(builder,
-             new SmtpClient(host, port) { EnableSsl = true, Credentials = new NetworkCredential (username, password) });
+             () => new SmtpClient(host, port) { EnableSsl = true, Credentials = new NetworkCredential (username, password) });
         
         public static FluentEmailServicesBuilder AddSmtpSender(this FluentEmailServicesBuilder builder, Func<SmtpClient> clientFactory)
         {


### PR DESCRIPTION
Resolves "An asynchronous call is already in progress." error message due to SmtpClient being instantiated during startup and reused, irrespective of it being defined as a Scoped service.

Fixes #154 