### PR TITLE
Ensure the subject is utf-8 encoded

### DIFF
--- a/src/Senders/FluentEmail.MailKit/MailKitSender.cs
+++ b/src/Senders/FluentEmail.MailKit/MailKitSender.cs
@@ -166,7 +166,10 @@ namespace FluentEmail.MailKitSmtp
         {
             var data = email.Data;
 
-            var message = new MimeMessage();
+            var message = new MimeMessage
+            {
+                Subject = data.Subject ?? string.Empty
+            };
             message.Headers.Add(HeaderId.Subject, Encoding.UTF8, data.Subject ?? string.Empty);
             message.Headers.Add(HeaderId.Encoding, Encoding.UTF8.EncodingName);
 

--- a/src/Senders/FluentEmail.MailKit/MailKitSender.cs
+++ b/src/Senders/FluentEmail.MailKit/MailKitSender.cs
@@ -166,10 +166,9 @@ namespace FluentEmail.MailKitSmtp
         {
             var data = email.Data;
 
-            MimeMessage message = new MimeMessage
-            {
-                Subject = data.Subject ?? string.Empty
-            };
+            var message = new MimeMessage();
+            message.Headers.Add(HeaderId.Subject, Encoding.UTF8, data.Subject ?? string.Empty);
+            message.Headers.Add(HeaderId.Encoding, Encoding.UTF8.EncodingName);
 
             message.From.Add(new MailboxAddress(data.FromAddress.Name, data.FromAddress.EmailAddress));
 


### PR DESCRIPTION
Hey @lukencode, I've tried to send a mail with the subject line "Vielen Dank für Ihre Registrierung". Without my modifications the MailKit did cause following headers:

Content-Id: <QCG39HVEDAU4.MDARRMP99QTJ3@localhost.localdomain>
Content-Type: text/html; charset=utf-8
Date: Tue, 14 Apr 2020 22:39:49 +0200
From: dev@somedomain.de
MIME-Version: 1.0
Message-Id: <OBYZCCVEDAU4.28XI177LT6OB@localhost.localdomain>
Received: from [127.0.0.1] by mailhog.example (MailHog)
          id RQIVAZNd97u58c8I_8jOoVPamf-qeP64uDjyr9vCOe8=@mailhog.example; Tue, 14 Apr 2020 20:52:43 +0000
Return-Path: <dev@somedomain.de>
Subject: Vielen Dank =?iso-8859-1?b?Zvxy?= Ihre Registrierung
To: Stanley3@test.local

With my modifications it looks imho a bit better as as the content and subject are both encoded with UTF-8:

Content-Id: <S1S7K13FDAU4.4Q33LGKRBX783@Viktors-MacBook-Pro.local>
Content-Type: text/html; charset=utf-8
Date: Tue, 14 Apr 2020 23:07:45 +0200
Encoding: Unicode (UTF-8)
From: dev@somedomain.de
MIME-Version: 1.0
Message-Id: <O4X3K13FDAU4.ZAYY7ETRSS0I1@Viktors-MacBook-Pro.local>
Received: from [127.0.0.1] by mailhog.example (MailHog)
          id gFOIixUEFB3rng8ej1yvmgzMko-EK0_s6dAwmK-TkgM=@mailhog.example; Tue, 14 Apr 2020 21:07:45 +0000
Return-Path: <dev@somedomain.de>
Subject: Vielen Dank =?utf-8?b?ZsO8cg==?= Ihre Registrierung
To: Stanley+4@test.local

I've been used https://github.com/mailhog/MailHog in order to see all headers as plain text which does help me a lot, but could not render the subject properly in case of using different encodings for the content and subject line.