### PR TITLE
Failing Tests (github actions)

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -2,9 +2,9 @@ name: Build & Test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ FixTestFail ]
   pull_request:
-    branches: [ master ]
+    branches: [ FixTestFail ]
 
 jobs:
   build:

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -2,9 +2,9 @@ name: Build & Test
 
 on:
   push:
-    branches: [ FixTestFail ]
+    branches: [ master ]
   pull_request:
-    branches: [ FixTestFail ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/test/FluentEmail.Core.Tests/AttachmentTests.cs
+++ b/test/FluentEmail.Core.Tests/AttachmentTests.cs
@@ -17,7 +17,7 @@ namespace FluentEmail.Core.Tests
         [Test]
         public void Attachment_from_stream_Is_set()
         {
-            using (var stream = File.OpenRead($"{Directory.GetCurrentDirectory()}/Test.txt"))
+            using (var stream = File.OpenRead($"{Path.Combine(Directory.GetCurrentDirectory(), "test.txt")}"))
             {
                 var attachment = new Attachment()
                 {
@@ -41,7 +41,7 @@ namespace FluentEmail.Core.Tests
             var email = Email.From(fromEmail)
                 .To(toEmail)
                 .Subject(subject)
-                .AttachFromFilename($"{Directory.GetCurrentDirectory()}/Test.txt", "text/plain");
+                .AttachFromFilename($"{Path.Combine(Directory.GetCurrentDirectory(), "test.txt")}", "text/plain");
 
             Assert.AreEqual(20, email.Data.Attachments.First().Data.Length);
         }
@@ -49,18 +49,6 @@ namespace FluentEmail.Core.Tests
         [Test]
         public void Attachment_from_filename_AttachmentName_Is_set()
         {
-
-            // THis is the first failing tests - the test is unable to locat the text.txt file.
-            System.Console.WriteLine($" MMH : {Directory.GetCurrentDirectory()}" );
-            System.Console.WriteLine($" MH : { Directory.GetCurrentDirectory()}/Test.txt");
-            var attachmentExists = File.Exists($"{Directory.GetCurrentDirectory()}/Test.txt");
-            System.Console.WriteLine($" MH : File exists : {attachmentExists}");
-            System.Console.WriteLine($" MH : { Directory.GetCurrentDirectory()}/Test.txt");
-            System.Console.WriteLine($" MH : File exists : {File.Exists(Path.Combine(Directory.GetCurrentDirectory(), "Test.txt"))}");
-            System.Console.WriteLine($" MH : File exists : {File.Exists(Path.Combine(Directory.GetCurrentDirectory(), "test.txt"))}");
-
-
-
             var attachmentName = "attachment.txt";
             var email = Email.From(fromEmail)
                 .To(toEmail)

--- a/test/FluentEmail.Core.Tests/AttachmentTests.cs
+++ b/test/FluentEmail.Core.Tests/AttachmentTests.cs
@@ -49,11 +49,23 @@ namespace FluentEmail.Core.Tests
         [Test]
         public void Attachment_from_filename_AttachmentName_Is_set()
         {
+
+            // THis is the first failing tests - the test is unable to locat the text.txt file.
+            System.Console.WriteLine($" MMH : {Directory.GetCurrentDirectory()}" );
+            System.Console.WriteLine($" MH : { Directory.GetCurrentDirectory()}/Test.txt");
+            var attachmentExists = File.Exists($"{Directory.GetCurrentDirectory()}/Test.txt");
+            System.Console.WriteLine($" MH : File exists : {attachmentExists}");
+            System.Console.WriteLine($" MH : { Directory.GetCurrentDirectory()}/Test.txt");
+            System.Console.WriteLine($" MH : File exists : {File.Exists(Path.Combine(Directory.GetCurrentDirectory(), "Test.txt"))}");
+            System.Console.WriteLine($" MH : File exists : {File.Exists(Path.Combine(Directory.GetCurrentDirectory(), "test.txt"))}");
+
+
+
             var attachmentName = "attachment.txt";
             var email = Email.From(fromEmail)
                 .To(toEmail)
                 .Subject(subject)
-                .AttachFromFilename($"{Directory.GetCurrentDirectory()}/Test.txt", "text/plain", attachmentName);
+                .AttachFromFilename($"{Path.Combine(Directory.GetCurrentDirectory(), "test.txt")}", "text/plain", attachmentName);
 
             Assert.AreEqual(20, email.Data.Attachments.First().Data.Length);
             Assert.AreEqual(attachmentName, email.Data.Attachments.First().Filename);

--- a/test/FluentEmail.Core.Tests/FluentEmail.Core.Tests.csproj
+++ b/test/FluentEmail.Core.Tests/FluentEmail.Core.Tests.csproj
@@ -31,4 +31,16 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Update="test-embedded.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Update="test.he-IL.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Update="test.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+  </ItemGroup>
+
 </Project>

--- a/test/FluentEmail.Core.Tests/TemplateEmailTests.cs
+++ b/test/FluentEmail.Core.Tests/TemplateEmailTests.cs
@@ -23,7 +23,7 @@ namespace FluentEmail.Core.Tests
 				.From(fromEmail)
 				.To(toEmail)
 				.Subject(subject)
-				.UsingTemplateFromFile($"{Directory.GetCurrentDirectory()}/Test.txt", new { Test = "FLUENTEMAIL" });
+				.UsingTemplateFromFile($"{Path.Combine(Directory.GetCurrentDirectory(), "test.txt")}", new { Test = "FLUENTEMAIL" });
 
 			Assert.AreEqual("yo email FLUENTEMAIL", email.Data.Body);
 		}
@@ -36,7 +36,7 @@ namespace FluentEmail.Core.Tests
 				.From(fromEmail)
 				.To(toEmail)
 				.Subject(subject)
-				.UsingCultureTemplateFromFile($"{Directory.GetCurrentDirectory()}/Test.txt", new { Test = "FLUENTEMAIL", culture }, culture);
+				.UsingCultureTemplateFromFile($"{Path.Combine(Directory.GetCurrentDirectory(), "test.txt")}", new { Test = "FLUENTEMAIL", culture }, culture);
 
 			Assert.AreEqual("yo email FLUENTEMAIL", email.Data.Body);
 		}
@@ -49,7 +49,7 @@ namespace FluentEmail.Core.Tests
 				.From(fromEmail)
 				.To(toEmail)
 				.Subject(subject)
-				.UsingCultureTemplateFromFile($"{Directory.GetCurrentDirectory()}/Test.txt", new { Test = "FLUENTEMAIL" }, culture);
+				.UsingCultureTemplateFromFile($"{Path.Combine(Directory.GetCurrentDirectory(), "test.txt")}", new { Test = "FLUENTEMAIL" }, culture);
 
 			Assert.AreEqual("hebrew email FLUENTEMAIL", email.Data.Body);
 		}
@@ -62,7 +62,7 @@ namespace FluentEmail.Core.Tests
 	            .From(fromEmail)
 	            .To(toEmail)
 	            .Subject(subject)
-	            .UsingCultureTemplateFromFile($"{Directory.GetCurrentDirectory()}/Test.txt", new {Test = "FLUENTEMAIL"}, culture);
+	            .UsingCultureTemplateFromFile($"{Path.Combine(Directory.GetCurrentDirectory(), "test.txt")}", new {Test = "FLUENTEMAIL"}, culture);
 
 	        Assert.AreEqual("hebrew email FLUENTEMAIL", email.Data.Body);
 	    }
@@ -116,7 +116,7 @@ namespace FluentEmail.Core.Tests
 			var email = new Email(fromEmail)
 				.To(toEmail)
 				.Subject(subject)
-				.UsingTemplateFromFile($"{Directory.GetCurrentDirectory()}/Test.txt", new { Test = "FLUENTEMAIL" });
+				.UsingTemplateFromFile($"{Path.Combine(Directory.GetCurrentDirectory(), "test.txt")}", new { Test = "FLUENTEMAIL" });
 
 			Assert.AreEqual("yo email FLUENTEMAIL", email.Data.Body);
 		}
@@ -128,7 +128,7 @@ namespace FluentEmail.Core.Tests
 			var email = new Email(fromEmail)
 				.To(toEmail)
 				.Subject(subject)
-				.UsingCultureTemplateFromFile($"{Directory.GetCurrentDirectory()}/Test.txt", new { Test = "FLUENTEMAIL", culture }, culture);
+				.UsingCultureTemplateFromFile($"{Path.Combine(Directory.GetCurrentDirectory(), "test.txt")}", new { Test = "FLUENTEMAIL", culture }, culture);
 
 			Assert.AreEqual("yo email FLUENTEMAIL", email.Data.Body);
 		}
@@ -140,7 +140,7 @@ namespace FluentEmail.Core.Tests
 			var email = new Email(fromEmail)
 				.To(toEmail)
 				.Subject(subject)
-				.UsingCultureTemplateFromFile($"{Directory.GetCurrentDirectory()}/Test.txt", new { Test = "FLUENTEMAIL" }, culture);
+				.UsingCultureTemplateFromFile($"{Path.Combine(Directory.GetCurrentDirectory(), "test.txt")}", new { Test = "FLUENTEMAIL" }, culture);
 
 			Assert.AreEqual("hebrew email FLUENTEMAIL", email.Data.Body);
 		}
@@ -152,7 +152,7 @@ namespace FluentEmail.Core.Tests
 	        var email = new Email(fromEmail)
 	            .To(toEmail)
 	            .Subject(subject)
-	            .UsingCultureTemplateFromFile($"{Directory.GetCurrentDirectory()}/Test.txt", new {Test = "FLUENTEMAIL"}, culture);
+	            .UsingCultureTemplateFromFile($"{Path.Combine(Directory.GetCurrentDirectory(), "test.txt")}", new {Test = "FLUENTEMAIL"}, culture);
 
 	        Assert.AreEqual("hebrew email FLUENTEMAIL", email.Data.Body);
 	    }


### PR DESCRIPTION
I noticed there were a bunch of failing tests (11).  I found that the messages were complaining that the tests couldn't find a file (called test.txt).

I saw that the project did not include a copy always, so I have set the Copy Always flag for these files.  They were being copied, but I thought this more explicit.  

I digress - this was not the main issue.  The issue is that running these tests under a linux environment introduces File name case sensitivity.  These tests were referring to Test.txt, rather than test.txt.

I have corrected the case for these tests, and additionally constructed the path using path.combine - which will add the appropriate environment symbol for path separation.