### PR TITLE
Replace consumption of List with IList, Dictionary with IEnumerable<KeyValuePair> or IDictionary

### DIFF
--- a/src/FluentEmail.Core/ListExtensions.cs
+++ b/src/FluentEmail.Core/ListExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace FluentEmail.Core
+{
+    public static class ListExtensions
+    {
+        public static void ForEach<T>(this IEnumerable<T> enumerable, Action<T> consumer)
+        {
+            foreach (T item in enumerable)
+            {
+                consumer(item);
+            }
+        }
+
+        public static void AddRange<T>(this IList<T> list, IEnumerable<T> items)
+        {
+            if (list is List<T> listT)
+            {
+                listT.AddRange(items);
+            }
+            else
+            {
+                foreach (T item in items)
+                {
+                    list.Add(item);
+                }
+            }
+        }
+    }
+}

--- a/src/FluentEmail.Core/Models/EmailData.cs
+++ b/src/FluentEmail.Core/Models/EmailData.cs
@@ -4,20 +4,20 @@ namespace FluentEmail.Core.Models
 {
     public class EmailData
     {
-        public List<Address> ToAddresses { get; set; }
-        public List<Address> CcAddresses { get; set; }
-        public List<Address> BccAddresses { get; set; }
-        public List<Address> ReplyToAddresses { get; set; }
-        public List<Attachment> Attachments { get; set; }
+        public IList<Address> ToAddresses { get; set; }
+        public IList<Address> CcAddresses { get; set; }
+        public IList<Address> BccAddresses { get; set; }
+        public IList<Address> ReplyToAddresses { get; set; }
+        public IList<Attachment> Attachments { get; set; }
         public Address FromAddress { get; set; }
         public string Subject { get; set; }
         public string Body { get; set; }
         public string PlaintextAlternativeBody { get; set; }
         public Priority Priority { get; set; }
-        public List<string> Tags { get; set; }
+        public IList<string> Tags { get; set; }
 
         public bool IsHtml { get; set; }
-        public Dictionary<string, string> Headers { get; set; }
+        public IDictionary<string, string> Headers { get; set; }
 
         public EmailData()
         {

--- a/src/FluentEmail.Core/Models/SendResponse.cs
+++ b/src/FluentEmail.Core/Models/SendResponse.cs
@@ -6,7 +6,7 @@ namespace FluentEmail.Core.Models
     public class SendResponse
     {
         public string MessageId { get; set; }
-        public List<string> ErrorMessages { get; set; }
+        public IList<string> ErrorMessages { get; set; }
         public bool Successful => !ErrorMessages.Any();
 
         public SendResponse()

--- a/src/Senders/FluentEmail.Mailgun/HttpHelpers/ApiResponse.cs
+++ b/src/Senders/FluentEmail.Mailgun/HttpHelpers/ApiResponse.cs
@@ -6,7 +6,7 @@ namespace FluentEmail.Mailgun.HttpHelpers
     public class ApiResponse
     {
         public bool Success => !Errors.Any();
-        public List<ApiError> Errors { get; set; }
+        public IList<ApiError> Errors { get; set; }
 
         public ApiResponse()
         {

--- a/src/Senders/FluentEmail.Mailgun/HttpHelpers/HttpClientHelpers.cs
+++ b/src/Senders/FluentEmail.Mailgun/HttpHelpers/HttpClientHelpers.cs
@@ -11,7 +11,7 @@ namespace FluentEmail.Mailgun.HttpHelpers
 {
     public class HttpClientHelpers
     {
-        public static HttpContent GetPostBody(Dictionary<string, string> parameters)
+        public static HttpContent GetPostBody(IEnumerable<KeyValuePair<string, string>> parameters)
         {
             var formatted = parameters.Select(x => x.Key + "=" + x.Value);
             return new StringContent(string.Join("&", formatted), Encoding.UTF8, "application/x-www-form-urlencoded");
@@ -22,7 +22,7 @@ namespace FluentEmail.Mailgun.HttpHelpers
             return new StringContent(JsonConvert.SerializeObject(value), Encoding.UTF8, "application/json");
         }
 
-        public static HttpContent GetMultipartFormDataContentBody(List<KeyValuePair<string, string>> parameters, List<HttpFile> files)
+        public static HttpContent GetMultipartFormDataContentBody(IEnumerable<KeyValuePair<string, string>> parameters, IEnumerable<HttpFile> files)
         {
             var mpContent = new MultipartFormDataContent();
 
@@ -60,7 +60,7 @@ namespace FluentEmail.Mailgun.HttpHelpers
             return qr.ToApiResponse();
         }
 
-        public static async Task<ApiResponse<T>> Post<T>(this HttpClient client, string url, Dictionary<string, string> parameters)
+        public static async Task<ApiResponse<T>> Post<T>(this HttpClient client, string url, IEnumerable<KeyValuePair<string, string>> parameters)
         {
             var response = await client.PostAsync(url, HttpClientHelpers.GetPostBody(parameters));
             var qr = await QuickResponse<T>.FromMessage(response);
@@ -74,7 +74,7 @@ namespace FluentEmail.Mailgun.HttpHelpers
             return qr.ToApiResponse();
         }
 
-        public static async Task<ApiResponse<T>> PostMultipart<T>(this HttpClient client, string url, List<KeyValuePair<string, string>> parameters, List<HttpFile> files)
+        public static async Task<ApiResponse<T>> PostMultipart<T>(this HttpClient client, string url, IEnumerable<KeyValuePair<string, string>> parameters, IEnumerable<HttpFile> files)
         {
             var response = await client.PostAsync(url, HttpClientHelpers.GetMultipartFormDataContentBody(parameters, files)).ConfigureAwait(false);
             var qr = await QuickResponse<T>.FromMessage(response);
@@ -95,7 +95,7 @@ namespace FluentEmail.Mailgun.HttpHelpers
 
         public string ResponseBody { get; set; }
 
-        public List<ApiError> Errors { get; set; }
+        public IList<ApiError> Errors { get; set; }
 
         public QuickResponse()
         {

--- a/src/Senders/FluentEmail.Mailgun/HttpHelpers/HttpClientHelpers.cs
+++ b/src/Senders/FluentEmail.Mailgun/HttpHelpers/HttpClientHelpers.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using FluentEmail.Core;
 
 namespace FluentEmail.Mailgun.HttpHelpers
 {

--- a/src/Senders/FluentEmail.SendGrid/SendGridSender.cs
+++ b/src/Senders/FluentEmail.SendGrid/SendGridSender.cs
@@ -54,7 +54,7 @@ namespace FluentEmail.SendGrid
 
             if (email.Data.Headers.Any())
             {
-                mailMessage.AddHeaders(email.Data.Headers);
+                mailMessage.AddHeaders(email.Data.Headers.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
             }
 
             if (email.Data.IsHtml)


### PR DESCRIPTION
This makes the library a bit easier to use, as you don't have to convert your arrays to Lists to use functions taking an IList as a parameter. This naturally also applies to any other object implementing IList. I did the same for Dictionary, where I replaced parameters of type Dictionary with IEnumerable<KeyValuePair>, and properties of type Dictionary with IDictionary.