### PR TITLE
Upgrading RazorLight to rc 3

### DIFF
--- a/src/Renderers/FluentEmail.Razor/FluentEmail.Razor.csproj
+++ b/src/Renderers/FluentEmail.Razor/FluentEmail.Razor.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="RazorLight" Version="2.0.0-beta1" />
+    <PackageReference Include="RazorLight" Version="2.0.0-rc.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Renderers/FluentEmail.Razor/RazorRenderer.cs
+++ b/src/Renderers/FluentEmail.Razor/RazorRenderer.cs
@@ -10,61 +10,54 @@ using System.Threading.Tasks;
 namespace FluentEmail.Razor
 {
 	public class RazorRenderer : ITemplateRenderer
-    {
-	    private readonly RazorLightEngine _engine;
+	{
+		private readonly RazorLightEngine _engine;
 
-	    public RazorRenderer()
-	    {
-		    _engine = new RazorLightEngineBuilder()
-			    .UseMemoryCachingProvider()
-			    .Build();      
-	    }
-
-	    public RazorRenderer(string root)
-	    {
-		    _engine = new RazorLightEngineBuilder()
-			    .UseFilesystemProject(root ?? Directory.GetCurrentDirectory())
-			    .UseMemoryCachingProvider()
-			    .Build();      
-	    }
-
-	    public RazorRenderer(RazorLightProject project)
-	    {
-		    _engine = new RazorLightEngineBuilder()
-			    .UseProject(project)
+		public RazorRenderer(string root = null)
+		{
+			_engine = new RazorLightEngineBuilder()
+				.UseFileSystemProject(root ?? Directory.GetCurrentDirectory())
 				.UseMemoryCachingProvider()
-			    .Build();      
-	    }
+				.Build();
+		}
 
-	    public RazorRenderer(Type embeddedResRootType)
-	    {
-		    _engine = new RazorLightEngineBuilder()
-			    .UseEmbeddedResourcesProject(embeddedResRootType)
-			    .UseMemoryCachingProvider()
-			    .Build();      
-	    }
+		public RazorRenderer(RazorLightProject project)
+		{
+			_engine = new RazorLightEngineBuilder()
+				.UseProject(project)
+				.UseMemoryCachingProvider()
+				.Build();
+		}
 
-	    public async Task<string> ParseAsync<T>(string template, T model, bool isHtml = true)
-	    {            
-		    dynamic viewBag = (model as IViewBagModel)?.ViewBag;
-		    return await _engine.CompileRenderAsync<T>(GetHashString(template), template, model, viewBag);
-	    }
+		public RazorRenderer(Type embeddedResRootType)
+		{
+			_engine = new RazorLightEngineBuilder()
+				.UseEmbeddedResourcesProject(embeddedResRootType)
+				.UseMemoryCachingProvider()
+				.Build();
+		}
 
-	    string ITemplateRenderer.Parse<T>(string template, T model, bool isHtml)
-	    {
-		    return ParseAsync(template, model, isHtml).GetAwaiter().GetResult();
-	    }
+		public async Task<string> ParseAsync<T>(string template, T model, bool isHtml = true)
+		{
+			dynamic viewBag = (model as IViewBagModel)?.ViewBag;
+			return await _engine.CompileRenderStringAsync<T>(GetHashString(template), template, model, viewBag);
+		}
 
-	    public static string GetHashString(string inputString)
-	    {
-		    var sb = new StringBuilder();
-		    var hashbytes = SHA256.Create().ComputeHash(Encoding.UTF8.GetBytes(inputString));
-		    foreach (byte b in hashbytes)
-		    {
-			    sb.Append(b.ToString("X2"));
-		    }
+		string ITemplateRenderer.Parse<T>(string template, T model, bool isHtml)
+		{
+			return ParseAsync(template, model, isHtml).GetAwaiter().GetResult();
+		}
 
-		    return sb.ToString();
-	    }
-    }
+		public static string GetHashString(string inputString)
+		{
+			var sb = new StringBuilder();
+			var hashbytes = SHA256.Create().ComputeHash(Encoding.UTF8.GetBytes(inputString));
+			foreach (byte b in hashbytes)
+			{
+				sb.Append(b.ToString("X2"));
+			}
+
+			return sb.ToString();
+		}
+	}
 }


### PR DESCRIPTION
There were a couple of breaking changes on RazorLight ahead of beta1 version currently used by FluentEmail.

With this change, FluentEmail can now use the latest version of RazorLight.