### PR TITLE
Add Liquid template language support

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -25,18 +25,21 @@ jobs:
           PROJECT_FILE_PATH: src/FluentEmail.Core/FluentEmail.Core.csproj
           NUGET_KEY: ${{secrets.NUGET_API_KEY}}
           NUGET_SOURCE: https://api.nuget.org
+          INCLUDE_SYMBOLS: true
     - name: Publish FluentEmail.Smtp
       uses: brandedoutcast/publish-nuget@v2.5.2
       with:
           PROJECT_FILE_PATH: src/Senders/FluentEmail.Smtp/FluentEmail.Smtp.csproj
           NUGET_KEY: ${{secrets.NUGET_API_KEY}}
           NUGET_SOURCE: https://api.nuget.org
+          INCLUDE_SYMBOLS: true
     - name: Publish FluentEmail.Sendgrid
       uses: brandedoutcast/publish-nuget@v2.5.2
       with:
           PROJECT_FILE_PATH: src/Senders/FluentEmail.SendGrid/FluentEmail.SendGrid.csproj
           NUGET_KEY: ${{secrets.NUGET_API_KEY}}
           NUGET_SOURCE: https://api.nuget.org
+          INCLUDE_SYMBOLS: true
     #- name: Publish FluentEmail.MailTrap
     #  uses: brandedoutcast/publish-nuget@v2.5.2
     #  with:
@@ -49,18 +52,28 @@ jobs:
           PROJECT_FILE_PATH: src/Senders/FluentEmail.MailKit/FluentEmail.MailKit.csproj
           NUGET_KEY: ${{secrets.NUGET_API_KEY}}
           NUGET_SOURCE: https://api.nuget.org
+          INCLUDE_SYMBOLS: true
     - name: Publish FluentEmail.Mailgun
       uses: brandedoutcast/publish-nuget@v2.5.2
       with:
           PROJECT_FILE_PATH: src/Senders/FluentEmail.Mailgun/FluentEmail.Mailgun.csproj
           NUGET_KEY: ${{secrets.NUGET_API_KEY}}
           NUGET_SOURCE: https://api.nuget.org
+          INCLUDE_SYMBOLS: true
     - name: Publish FluentEmail.Razor
       uses: brandedoutcast/publish-nuget@v2.5.2
       with:
           PROJECT_FILE_PATH: src/Renderers/FluentEmail.Razor/FluentEmail.Razor.csproj
           NUGET_KEY: ${{secrets.NUGET_API_KEY}}
           NUGET_SOURCE: https://api.nuget.org
+          INCLUDE_SYMBOLS: true
+    - name: Publish FluentEmail.Liquid
+      uses: brandedoutcast/publish-nuget@v2.5.2
+      with:
+          PROJECT_FILE_PATH: src/Renderers/FluentEmail.Liquid/FluentEmail.Liquid.csproj
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+          NUGET_SOURCE: https://api.nuget.org
+          INCLUDE_SYMBOLS: true
     # This is currently maintained separately
     #- name: Publish FluentEmail.Graph
     #  uses: brandedoutcast/publish-nuget@v2.5.2

--- a/FluentEmail.sln
+++ b/FluentEmail.sln
@@ -53,6 +53,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FluentEmail.Graph", "src\Se
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentEmail.Graph.Tests", "test\FluentEmail.Graph.Tests\FluentEmail.Graph.Tests.csproj", "{A180EE2A-CD37-4762-8AC7-ADAC828FB4A0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentEmail.Liquid", "src\Renderers\FluentEmail.Liquid\FluentEmail.Liquid.csproj", "{17100F47-A555-4756-A25F-4F05EDAFA74E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentEmail.Liquid.Tests", "test\FluentEmail.Liquid.Tests\FluentEmail.Liquid.Tests.csproj", "{C8063CBA-D8F3-467A-A75C-63843F0DE862}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -123,6 +127,14 @@ Global
 		{A180EE2A-CD37-4762-8AC7-ADAC828FB4A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A180EE2A-CD37-4762-8AC7-ADAC828FB4A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A180EE2A-CD37-4762-8AC7-ADAC828FB4A0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{17100F47-A555-4756-A25F-4F05EDAFA74E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{17100F47-A555-4756-A25F-4F05EDAFA74E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{17100F47-A555-4756-A25F-4F05EDAFA74E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{17100F47-A555-4756-A25F-4F05EDAFA74E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C8063CBA-D8F3-467A-A75C-63843F0DE862}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C8063CBA-D8F3-467A-A75C-63843F0DE862}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C8063CBA-D8F3-467A-A75C-63843F0DE862}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C8063CBA-D8F3-467A-A75C-63843F0DE862}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -148,6 +160,8 @@ Global
 		{57718ED0-6B5D-419F-A5C5-1884BE3529A5} = {4DADBE55-BD91-4D14-92EA-1BD0D1545145}
 		{0C7819AD-BC76-465D-9B2A-BE2DA75042F2} = {926C0980-31D9-4449-903F-3C756044C28A}
 		{A180EE2A-CD37-4762-8AC7-ADAC828FB4A0} = {4DADBE55-BD91-4D14-92EA-1BD0D1545145}
+		{17100F47-A555-4756-A25F-4F05EDAFA74E} = {12F031E5-8DDC-40A0-9862-8764A6E190C0}
+		{C8063CBA-D8F3-467A-A75C-63843F0DE862} = {47CB89AC-9615-4FA8-90DE-2D849935C36D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {23736554-5288-4B30-9710-B4D9880BCF0B}

--- a/README.markdown
+++ b/README.markdown
@@ -6,32 +6,35 @@ The easiest way to send email from .NET and .NET Core. Use Razor for email templ
 
 ## Nuget Packages
 
-[FluentEmail.Core](src/FluentEmail.Core) - Just the domain model. Includes very basic defaults, but is also included with every other package here.
+### Core Library
 
-[FluentEmail.Smtp](src/Senders/FluentEmail.Smtp) - Send email via SMTP server.
+* [FluentEmail.Core](src/FluentEmail.Core) - Just the domain model. Includes very basic defaults, but is also included with every other package here.
+* [FluentEmail.Smtp](src/Senders/FluentEmail.Smtp) - Send email via SMTP server.
 
-[FluentEmail.Razor](src/Renderers/FluentEmail.Razor) - Generate emails using Razor templates. Anything you can do in ASP.NET is possible here. Uses the [RazorLight](https://github.com/toddams/RazorLight) project under the hood. 
+### Renderers
 
-[FluentEmail.Mailgun](src/Senders/FluentEmail.Mailgun) - Send emails via MailGun's REST API.
+* [FluentEmail.Razor](src/Renderers/FluentEmail.Razor) - Generate emails using Razor templates. Anything you can do in ASP.NET is possible here. Uses the [RazorLight](https://github.com/toddams/RazorLight) project under the hood. 
+* [FluentEmail.Liquid](src/Renderers/FluentEmail.Liquid) - Generate emails using [Liquid templates](https://shopify.github.io/liquid/). Uses the [Fluid](https://github.com/sebastienros/fluid) project under the hood. 
 
-[FluentEmail.SendGrid](src/Senders/FluentEmail.SendGrid) - Send email via the SendGrid API.
+### Mail Provider Integrations
 
-[FluentEmail.Mailtrap](src/Senders/FluentEmail.Mailtrap) - Send emails to Mailtrap. Uses [FluentEmail.Smtp](src/Senders/FluentEmail.Smtp) for delivery.
+* [FluentEmail.Mailgun](src/Senders/FluentEmail.Mailgun) - Send emails via MailGun's REST API.
+* [FluentEmail.SendGrid](src/Senders/FluentEmail.SendGrid) - Send email via the SendGrid API.
+* [FluentEmail.Mailtrap](src/Senders/FluentEmail.Mailtrap) - Send emails to Mailtrap. Uses [FluentEmail.Smtp](src/Senders/FluentEmail.Smtp) for delivery.
+* [FluentEmail.MailKit](src/Senders/FluentEmail.MailKit) - Send emails using the [MailKit](https://github.com/jstedfast/MailKit) email library.
 
-[FluentEmail.MailKit](src/Senders/FluentEmail.MailKit) - Send emails using the [MailKit](https://github.com/jstedfast/MailKit) email library.
-
-**Basic Usage**
+## Basic Usage
 ```csharp
 var email = await Email
-    	.From("john@email.com")
-    	.To("bob@email.com", "bob")
-    	.Subject("hows it going bob")
-    	.Body("yo bob, long time no see!")
-	.SendAsync();
+    .From("john@email.com")
+    .To("bob@email.com", "bob")
+    .Subject("hows it going bob")
+    .Body("yo bob, long time no see!")
+    .SendAsync();
 ```
 
 
-**Dependency Injection**
+## Dependency Injection
 
 Configure FluentEmail in startup.cs with these helper methods. This will inject IFluentEmail (send a single email) and IFluentEmailFactory (used to send multiple emails in a single context) with the 
 ISender and ITemplateRenderer configured using AddRazorRenderer(), AddSmtpSender() or other packages.
@@ -39,14 +42,14 @@ ISender and ITemplateRenderer configured using AddRazorRenderer(), AddSmtpSender
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
-	services
-		.AddFluentEmail("fromemail@test.test")
-		.AddRazorRenderer()
-		.AddSmtpSender("localhost", 25);
+    services
+        .AddFluentEmail("fromemail@test.test")
+        .AddRazorRenderer()
+        .AddSmtpSender("localhost", 25);
 }
 ```
 
-**Using a template**
+## Using a Razor template
 
 ```csharp
 // Using Razor templating package (or set using AddRazorRenderer in services)
@@ -61,7 +64,42 @@ var email = Email
     .UsingTemplate(template, new { Name = "Luke", Compliment = "Awesome" });
 ```
 
-**Sending Emails**
+## Using a Liquid template
+
+[Liquid templates](https://shopify.github.io/liquid/) are a more secure option for Razor templates as they run in more restricted environment.
+While Razor templates have access to whole power of CLR functionality like file access, they also
+are more insecure if templates come from untrusted source. Liquid templates also have the benefit of being faster
+to parse initially as they don't need heavy compilation step like Razor templates do.
+
+Model properties are exposed directly as properties in Liquid templates so they also become more compact.
+
+See [Fluid samples](https://github.com/sebastienros/fluid) for more examples.
+
+```csharp
+// Using Liquid templating package (or set using AddLiquidRenderer in services)
+
+// file provider is used to resolve layout files if they are in use
+var fileProvider = new PhysicalFileProvider(Path.Combine(someRootPath, "EmailTemplates"));
+var options = new LiquidRendererOptions
+{
+    FileProvider = fileProvider
+};
+
+Email.DefaultRenderer = new LiquidRenderer(Options.Create(options));
+
+// template which utilizes layout
+var template = @"
+{% layout '_layout.liquid' %}
+Dear {{ Name }}, You are totally {{ Compliment }}.";
+
+var email = Email
+    .From("bob@hotmail.com")
+    .To("somedude@gmail.com")
+    .Subject("woo nuget")
+    .UsingTemplate(template, new ViewModel { Name = "Luke", Compliment = "Awesome" });
+```
+
+## Sending Emails
 
 ```csharp
 // Using Smtp Sender package (or set using AddSmtpSender in services)
@@ -74,7 +112,7 @@ email.Send();
 await email.SendAsync();
 ```
 
-**Template File from Disk**  
+## Template File from Disk
 
 ```csharp
 var email = Email
@@ -84,7 +122,7 @@ var email = Email
     .UsingTemplateFromFile($"{Directory.GetCurrentDirectory()}/Mytemplate.cshtml", new { Name = "Rad Dude" });
 ```
 
-**Embedded Template File**  
+## Embedded Template File
 
 **Note for .NET Core 2 users:** You'll need to add the following line to the project containing any embedded razor views. See [this issue for more details](https://github.com/aspnet/Mvc/issues/6021).
 
@@ -101,10 +139,11 @@ var email = new Email("bob@hotmail.com")
 		TypeFromYourEmbeddedAssembly.GetType().GetTypeInfo().Assembly);
 ```
 
-**More Info**
+## More Info
 
 <a href="http://lukencode.com/2018/07/01/send-email-in-dotnet-core-with-fluent-email/">Sending email in .NET Core with FluentEmail</a>
 
 
-**[The future of FluentEmail](https://lukelowrey.com/fluentemail-future/)**
+## [The future of FluentEmail](https://lukelowrey.com/fluentemail-future/)**
+
 Looking for collaborators, discussion and hoping to keep improving the library!

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -26,6 +26,8 @@
 
     <AssetsDirectory>../../../assets</AssetsDirectory>
 
+    <LangVersion>latest</LangVersion>
+
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FluentEmail.Core/FluentEmail.Core.csproj
+++ b/src/FluentEmail.Core/FluentEmail.Core.csproj
@@ -13,7 +13,7 @@
   </Target>-->
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.11" />
   </ItemGroup>
 
 </Project>

--- a/src/Renderers/FluentEmail.Liquid/FluentEmail.Liquid.csproj
+++ b/src/Renderers/FluentEmail.Liquid/FluentEmail.Liquid.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Generate emails using Liquid templates. Uses the Fluid project under the hood.</Description>
+    <AssemblyTitle>Fluent Email - Liquid</AssemblyTitle>
+    <PackageTags>$(PackageTags);liquid</PackageTags>
+    <Version>2.9.0</Version>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssetsDirectory>../../../assets</AssetsDirectory>
+    <NoWarn>NU5104</NoWarn>
+    <RootNamespace>FluentEmail.Liquid</RootNamespace>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Fluid.Core" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.11" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\FluentEmail.Core\FluentEmail.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Renderers/FluentEmail.Liquid/FluentEmailFluidBuilderExtensions.cs
+++ b/src/Renderers/FluentEmail.Liquid/FluentEmailFluidBuilderExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+
+using FluentEmail.Core.Interfaces;
+using FluentEmail.Liquid;
+
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class FluentEmailFluidBuilderExtensions
+    {
+        public static FluentEmailServicesBuilder AddLiquidRenderer(
+            this FluentEmailServicesBuilder builder,
+            Action<LiquidRendererOptions>? configure = null)
+        {
+            builder.Services.AddOptions<LiquidRendererOptions>();
+            if (configure != null)
+            {
+                builder.Services.Configure(configure);
+            }
+
+            builder.Services.TryAddSingleton<ITemplateRenderer, LiquidRenderer>();
+            return builder;
+        }
+    }
+}

--- a/src/Renderers/FluentEmail.Liquid/FluidViewTemplate.cs
+++ b/src/Renderers/FluentEmail.Liquid/FluidViewTemplate.cs
@@ -1,0 +1,17 @@
+﻿using FluentEmail.Liquid.Tags;
+
+using Fluid;
+
+namespace FluentEmail.Liquid
+{
+    public class FluidViewTemplate : BaseFluidTemplate<FluidViewTemplate>
+    {
+        static FluidViewTemplate()
+        {
+            Factory.RegisterTag<LayoutTag>("layout");
+            Factory.RegisterTag<RenderBodyTag>("renderbody");
+            Factory.RegisterBlock<RegisterSectionBlock>("section");
+            Factory.RegisterTag<RenderSectionTag>("rendersection");
+        }
+    }
+}

--- a/src/Renderers/FluentEmail.Liquid/LiquidRenderer.cs
+++ b/src/Renderers/FluentEmail.Liquid/LiquidRenderer.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using FluentEmail.Core.Interfaces;
+using Fluid;
+using Fluid.Ast;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+
+namespace FluentEmail.Liquid
+{
+    public class LiquidRenderer : ITemplateRenderer
+    {
+        private static readonly Func<IFluidTemplate> FluidTemplateFactory = () => new FluidViewTemplate();
+
+        private readonly IOptions<LiquidRendererOptions> _options;
+
+        public LiquidRenderer(IOptions<LiquidRendererOptions> options)
+        {
+            _options = options;
+        }
+
+        public string Parse<T>(string template, T model, bool isHtml = true)
+        {
+            return ParseAsync(template, model, isHtml).GetAwaiter().GetResult();
+        }
+
+        public async Task<string> ParseAsync<T>(string template, T model, bool isHtml = true)
+        {
+            var rendererOptions = _options.Value;
+
+            // Check for a custom file provider
+            var fileProvider = rendererOptions.FileProvider;
+            var viewTemplate = ParseTemplate(template);
+
+            var context = new TemplateContext(model)
+            {
+                // provide some services to all statements
+                AmbientValues =
+                {
+                    ["FileProvider"] = fileProvider,
+                    ["Sections"] = new Dictionary<string, List<Statement>>()
+                },
+                ParserFactory = FluidViewTemplate.Factory,
+                TemplateFactory = FluidTemplateFactory,
+                FileProvider = fileProvider
+            };
+
+            rendererOptions.ConfigureTemplateContext?.Invoke(context, model!);
+
+            var body = await viewTemplate.RenderAsync(context, rendererOptions.TextEncoder);
+
+            // if a layout is specified while rendering a view, execute it
+            if (context.AmbientValues.TryGetValue("Layout", out var layoutPath))
+            {
+                context.AmbientValues["Body"] = body;
+                var layoutTemplate = ParseLiquidFile((string) layoutPath, fileProvider!);
+
+                return await layoutTemplate.RenderAsync(context, rendererOptions.TextEncoder);
+            }
+
+            return body;
+        }
+
+        private static FluidViewTemplate ParseLiquidFile(
+            string path,
+            IFileProvider? fileProvider)
+        {
+            static void ThrowMissingFileProviderException()
+            {
+                const string message = "Cannot parse external file, file provider missing";
+                throw new ArgumentNullException(nameof(LiquidRendererOptions.FileProvider), message);
+            }
+
+            if (fileProvider is null)
+            {
+                ThrowMissingFileProviderException();
+            }
+
+            var fileInfo = fileProvider!.GetFileInfo(path);
+            using var stream = fileInfo.CreateReadStream();
+            using var sr = new StreamReader(stream);
+
+            return ParseTemplate(sr.ReadToEnd());
+        }
+
+        private static FluidViewTemplate ParseTemplate(string content)
+        {
+            if (!FluidViewTemplate.TryParse(content, out var template, out var errors))
+            {
+                throw new Exception(string.Join(Environment.NewLine, errors));
+            }
+
+            return template;
+        }
+    }
+}

--- a/src/Renderers/FluentEmail.Liquid/LiquidRendererOptions.cs
+++ b/src/Renderers/FluentEmail.Liquid/LiquidRendererOptions.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Text.Encodings.Web;
+using Fluid;
+using Microsoft.Extensions.FileProviders;
+
+namespace FluentEmail.Liquid
+{
+    public class LiquidRendererOptions
+    {
+        /// <summary>
+        /// Allows configuring template context before running the template. Parameters are context that has been
+        /// prepared and the model that is going to be used.
+        /// </summary>
+        /// <remarks>
+        /// This API creates dependency on Fluid.
+        /// </remarks>
+        public Action<TemplateContext, object>? ConfigureTemplateContext { get; set; }
+
+        /// <summary>
+        /// Text encoder to use. Defaults to <see cref="HtmlEncoder"/>.
+        /// </summary>
+        public TextEncoder TextEncoder { get; set; } = HtmlEncoder.Default;
+
+        /// <summary>
+        /// File provider to use, used when resolving references in templates, like master layout.
+        /// </summary>
+        public IFileProvider? FileProvider { get; set; }
+    }
+}

--- a/src/Renderers/FluentEmail.Liquid/Tags/LayoutTag.cs
+++ b/src/Renderers/FluentEmail.Liquid/Tags/LayoutTag.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.IO;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+
+using Fluid;
+using Fluid.Ast;
+using Fluid.Tags;
+
+namespace FluentEmail.Liquid.Tags
+{
+    internal sealed class LayoutTag : ExpressionTag
+    {
+        private const string ViewExtension = ".liquid";
+
+        public override async ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context, Expression expression)
+        {
+            var relativeLayoutPath = (await expression.EvaluateAsync(context)).ToStringValue();
+            if (!relativeLayoutPath.EndsWith(ViewExtension, StringComparison.OrdinalIgnoreCase))
+            {
+                relativeLayoutPath += ViewExtension;
+            }
+
+            context.AmbientValues["Layout"] = relativeLayoutPath;
+            return Completion.Normal;
+        }
+    }
+}

--- a/src/Renderers/FluentEmail.Liquid/Tags/RegisterSectionBlock.cs
+++ b/src/Renderers/FluentEmail.Liquid/Tags/RegisterSectionBlock.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Fluid;
+using Fluid.Ast;
+using Fluid.Tags;
+
+namespace FluentEmail.Liquid.Tags
+{
+    internal sealed class RegisterSectionBlock : IdentifierBlock
+    {
+        private static readonly ValueTask<Completion> Normal = new ValueTask<Completion>(Completion.Normal);
+
+        public override ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context, string sectionName, List<Statement> statements)
+        {
+            if (context.AmbientValues.TryGetValue("Sections", out var sections))
+            {
+                var dictionary = (Dictionary<string, List<Statement>>) sections;
+                dictionary[sectionName] = statements;
+            }
+
+            return Normal;
+        }
+    }
+}

--- a/src/Renderers/FluentEmail.Liquid/Tags/RenderBodyTag.cs
+++ b/src/Renderers/FluentEmail.Liquid/Tags/RenderBodyTag.cs
@@ -1,0 +1,31 @@
+﻿using System.IO;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Fluid;
+using Fluid.Ast;
+using Fluid.Tags;
+
+namespace FluentEmail.Liquid.Tags
+{
+    internal sealed class RenderBodyTag : SimpleTag
+    {
+        public override async ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
+        {
+            static void ThrowParseException()
+            {
+                throw new ParseException("Could not render body, Layouts can't be evaluated directly.");
+            }
+
+            if (context.AmbientValues.TryGetValue("Body", out var body))
+            {
+                await writer.WriteAsync((string)body);
+            }
+            else
+            {
+                ThrowParseException();
+            }
+
+            return Completion.Normal;
+        }
+    }
+}

--- a/src/Renderers/FluentEmail.Liquid/Tags/RenderSectionTag.cs
+++ b/src/Renderers/FluentEmail.Liquid/Tags/RenderSectionTag.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Fluid;
+using Fluid.Ast;
+using Fluid.Tags;
+
+namespace FluentEmail.Liquid.Tags
+{
+    internal sealed class RenderSectionTag : IdentifierTag
+    {
+        public override async ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context, string sectionName)
+        {
+            if (context.AmbientValues.TryGetValue("Sections", out var sections))
+            {
+                var dictionary = (Dictionary<string, List<Statement>>) sections;
+                if (dictionary.TryGetValue(sectionName, out var section))
+                {
+                    foreach(var statement in section)
+                    {
+                        await statement.WriteToAsync(writer, encoder, context);
+                    }
+                }
+            }
+
+            return Completion.Normal;
+        }
+    }
+}

--- a/src/Renderers/FluentEmail.Razor/FluentEmail.Razor.csproj
+++ b/src/Renderers/FluentEmail.Razor/FluentEmail.Razor.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="RazorLight" Version="2.0.0-rc.3" />
   </ItemGroup>
 

--- a/test/FluentEmail.Liquid.Tests/EmailTemplates/_embedded.liquid
+++ b/test/FluentEmail.Liquid.Tests/EmailTemplates/_embedded.liquid
@@ -1,0 +1,2 @@
+﻿<h2>Hello!</h2>
+<div>{% renderbody %}</div>

--- a/test/FluentEmail.Liquid.Tests/EmailTemplates/_layout.liquid
+++ b/test/FluentEmail.Liquid.Tests/EmailTemplates/_layout.liquid
@@ -1,0 +1,2 @@
+﻿<h1>Hello!</h1>
+<div>{% renderbody %}</div>

--- a/test/FluentEmail.Liquid.Tests/FluentEmail.Liquid.Tests.csproj
+++ b/test/FluentEmail.Liquid.Tests/FluentEmail.Liquid.Tests.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="EmailTemplates\_layout.liquid" CopyToOutputDirectory="PreserveNewest" />
+    <EmbeddedResource Include="EmailTemplates\_embedded.liquid" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Renderers\FluentEmail.Liquid\FluentEmail.Liquid.csproj" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.11" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.1.11" />
+  </ItemGroup>
+
+</Project>

--- a/test/FluentEmail.Liquid.Tests/LiquidTests.cs
+++ b/test/FluentEmail.Liquid.Tests/LiquidTests.cs
@@ -1,0 +1,194 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using FluentEmail.Core;
+
+using Fluid;
+
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+
+using NUnit.Framework;
+
+namespace FluentEmail.Liquid.Tests
+{
+	public class LiquidTests
+    {
+	    private const string ToEmail = "bob@test.com";
+        private const string FromEmail = "johno@test.com";
+        private const string Subject = "sup dawg";
+
+        [SetUp]
+        public void SetUp()
+        {
+            // default to have no file provider, only required when layout files are in use
+            SetupRenderer(null);
+        }
+
+        private static void SetupRenderer(
+            IFileProvider fileProvider = null,
+            Action<TemplateContext, object> configureTemplateContext = null)
+        {
+            var options = new LiquidRendererOptions
+            {
+                FileProvider = fileProvider,
+                ConfigureTemplateContext = configureTemplateContext,
+            };
+            Email.DefaultRenderer = new LiquidRenderer(Options.Create(options));
+        }
+
+        [Test]
+        public void Model_With_List_Template_Matches()
+        {
+            const string template = "sup {{ Name }} here is a list {% for i in Numbers %}{{ i }}{% endfor %}";
+
+            var email = Email
+                .From(FromEmail)
+                .To(ToEmail)
+                .Subject(Subject)
+                .UsingTemplate(template, new ViewModel { Name = "LUKE", Numbers = new[] { "1", "2", "3" } });
+
+            Assert.AreEqual("sup LUKE here is a list 123", email.Data.Body);
+        }
+
+
+        [Test]
+        public void Custom_Context_Values()
+        {
+            SetupRenderer(new NullFileProvider(), (context, model) =>
+            {
+                context.SetValue("FirstName", "Samantha");
+                context.SetValue("IntegerNumbers", new[] {3, 2, 1});
+            });
+
+            const string template = "sup {{ FirstName }} here is a list {% for i in IntegerNumbers %}{{ i }}{% endfor %}";
+
+            var email = Email
+                .From(FromEmail)
+                .To(ToEmail)
+                .Subject(Subject)
+                .UsingTemplate(template, new ViewModel { Name = "LUKE", Numbers = new[] { "1", "2", "3" } });
+
+            Assert.AreEqual("sup Samantha here is a list 321", email.Data.Body);
+        }
+
+        // currently not cached as Fluid is so fast, but can be added later
+        [Test]
+        public void Reuse_Cached_Templates()
+        {
+            const string template = "sup {{ Name }} here is a list {% for i in Numbers %}{{ i }}{% endfor %}";
+            const string template2 = "sup {{ Name }} this is the second template";
+
+            for (var i = 0; i < 10; i++)
+            {
+                var email = Email
+                    .From(FromEmail)
+                    .To(ToEmail)
+                    .Subject(Subject)
+                    .UsingTemplate(template, new ViewModel { Name = i.ToString(), Numbers = new[] { "1", "2", "3" } });
+
+                Assert.AreEqual("sup " + i + " here is a list 123", email.Data.Body);
+
+                var email2 = Email
+                    .From(FromEmail)
+                    .To(ToEmail)
+                    .Subject(Subject)
+                    .UsingTemplate(template2, new ViewModel { Name = i.ToString() });
+
+                Assert.AreEqual("sup " + i + " this is the second template", email2.Data.Body);
+            }
+        }
+
+        [Test]
+        public void New_Model_Template_Matches()
+        {
+            const string template = "sup {{ Name }}";
+
+            var email = new Email(FromEmail)
+                .To(ToEmail)
+                .Subject(Subject)
+                .UsingTemplate(template, new ViewModel { Name = "LUKE" });
+
+            Assert.AreEqual("sup LUKE", email.Data.Body);
+        }
+
+        [Test]
+        public void New_Model_With_List_Template_Matches()
+        {
+            const string template = "sup {{ Name }} here is a list {% for i in Numbers %}{{ i }}{% endfor %}";
+
+            var email = new Email(FromEmail)
+                .To(ToEmail)
+                .Subject(Subject)
+                .UsingTemplate(template, new ViewModel { Name = "LUKE", Numbers = new[] { "1", "2", "3" } });
+
+            Assert.AreEqual("sup LUKE here is a list 123", email.Data.Body);
+        }
+
+        // currently not cached as Fluid is so fast, but can be added later
+        [Test]
+        public void New_Reuse_Cached_Templates()
+        {
+            const string template = "sup {{ Name }} here is a list {% for i in Numbers %}{{ i }}{% endfor %}";
+            const string template2 = "sup {{ Name }} this is the second template";
+
+            for (var i = 0; i < 10; i++)
+            {
+                var email = new Email(FromEmail)
+                    .To(ToEmail)
+                    .Subject(Subject)
+                    .UsingTemplate(template, new ViewModel { Name = i.ToString(), Numbers = new[] { "1", "2", "3" } });
+
+                Assert.AreEqual("sup " + i + " here is a list 123", email.Data.Body);
+
+                var email2 = new Email(FromEmail)
+                    .To(ToEmail)
+                    .Subject(Subject)
+                    .UsingTemplate(template2, new ViewModel { Name = i.ToString() });
+
+                Assert.AreEqual("sup " + i + " this is the second template", email2.Data.Body);
+            }
+        }
+
+	    [Test]
+	    public void Should_be_able_to_use_project_layout()
+	    {
+            SetupRenderer(new PhysicalFileProvider(Path.Combine(new FileInfo(Assembly.GetExecutingAssembly().Location).Directory.FullName, "EmailTemplates")));
+
+		    const string template = @"
+{% layout '_layout.liquid' %}
+sup {{ Name }} here is a list {% for i in Numbers %}{{ i }}{% endfor %}";
+
+			var email = new Email(FromEmail)
+			    .To(ToEmail)
+			    .Subject(Subject)
+			    .UsingTemplate(template, new ViewModel{ Name = "LUKE", Numbers = new[] { "1", "2", "3" } });
+
+		    Assert.AreEqual($"<h1>Hello!</h1>{Environment.NewLine}<div>{Environment.NewLine}sup LUKE here is a list 123</div>", email.Data.Body);
+	    }
+
+
+        [Test]
+        public void Should_be_able_to_use_embedded_layout()
+        {
+            SetupRenderer(new EmbeddedFileProvider(typeof(LiquidTests).Assembly, "FluentEmail.Liquid.Tests.EmailTemplates"));
+
+            const string template = @"
+{% layout '_embedded.liquid' %}
+sup {{ Name }} here is a list {% for i in Numbers %}{{ i }}{% endfor %}";
+
+            var email = new Email(FromEmail)
+                .To(ToEmail)
+                .Subject(Subject)
+                .UsingTemplate(template, new ViewModel{ Name = "LUKE", Numbers = new[] { "1", "2", "3" } });
+
+            Assert.AreEqual($"<h2>Hello!</h2>{Environment.NewLine}<div>{Environment.NewLine}sup LUKE here is a list 123</div>", email.Data.Body);
+        }
+
+        private class ViewModel
+        {
+            public string Name { get; set; }
+            public string[] Numbers { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Secure alternative to Razor, supporting Shopify's templating language, [Liquid](https://shopify.github.io/liquid/). Liquid templates and sandboxed and cannot access the CLR the same way as Razor (think malicious file access).

* Simple and well supported templating language (plugins available for major IDEs and editors)
* Using [Fluid](https://github.com/sebastienros/fluid) as underlying engine
   * Fast and secure, you can define what CLR access is allowed and recursion limits etc (unlike Razor)
   * Used in projects like OrchardCMS
* Adapted master page support from Fluid MVC view engine support

@lukencode Please let me know if this is something you don't want to consider as part of the main project.

