### PR TITLE
Allow caller to provide RazorLightEngine

### DIFF
--- a/src/Renderers/FluentEmail.Razor/FluentEmailRazorBuilderExtensions.cs
+++ b/src/Renderers/FluentEmail.Razor/FluentEmailRazorBuilderExtensions.cs
@@ -15,13 +15,13 @@ namespace Microsoft.Extensions.DependencyInjection
 		    return builder;
 	    }
 
-		/// <summary>
-		/// Add razor renderer with project views and layouts
-		/// </summary>
-		/// <param name="builder"></param>
-		/// <param name="templateRootFolder"></param>
-		/// <returns></returns>
-		public static FluentEmailServicesBuilder AddRazorRenderer(this FluentEmailServicesBuilder builder, string templateRootFolder)
+	    /// <summary>
+	    /// Add razor renderer with project views and layouts
+	    /// </summary>
+	    /// <param name="builder"></param>
+	    /// <param name="templateRootFolder"></param>
+	    /// <returns></returns>
+	    public static FluentEmailServicesBuilder AddRazorRenderer(this FluentEmailServicesBuilder builder, string templateRootFolder)
         {
             builder.Services.TryAdd(ServiceDescriptor.Singleton<ITemplateRenderer, RazorRenderer>(sp => new RazorRenderer(templateRootFolder)));
             return builder;
@@ -51,16 +51,16 @@ namespace Microsoft.Extensions.DependencyInjection
 		    return builder;
 	    }
 
-		/// <summary>
-		/// Add razor renderer with project views and layouts
-		/// </summary>
-		/// <param name="builder"></param>
-		/// <param name="razorLightEngine"></param>
-		/// <returns></returns>
-		public static FluentEmailServicesBuilder AddRazorRenderer(this FluentEmailServicesBuilder builder, RazorLightEngine razorLightEngine)
-		{
-			builder.Services.TryAdd(ServiceDescriptor.Singleton<ITemplateRenderer, RazorRenderer>(sp => new RazorRenderer(razorLightEngine)));
-			return builder;
-		}
+	    /// <summary>
+	    /// Add razor renderer with project views and layouts
+	    /// </summary>
+	    /// <param name="builder"></param>
+	    /// <param name="razorLightEngine"></param>
+	    /// <returns></returns>
+	    public static FluentEmailServicesBuilder AddRazorRenderer(this FluentEmailServicesBuilder builder, RazorLightEngine razorLightEngine)
+	    {
+		    builder.Services.TryAdd(ServiceDescriptor.Singleton<ITemplateRenderer, RazorRenderer>(sp => new RazorRenderer(razorLightEngine)));
+		    return builder;
+	    }
 	}
 }

--- a/src/Renderers/FluentEmail.Razor/FluentEmailRazorBuilderExtensions.cs
+++ b/src/Renderers/FluentEmail.Razor/FluentEmailRazorBuilderExtensions.cs
@@ -2,6 +2,7 @@
 using FluentEmail.Core.Interfaces;
 using FluentEmail.Razor;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using RazorLight;
 using RazorLight.Razor;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -14,13 +15,13 @@ namespace Microsoft.Extensions.DependencyInjection
 		    return builder;
 	    }
 
-	    /// <summary>
-	    /// Add razor renderer with project views and layouts
-	    /// </summary>
-	    /// <param name="builder"></param>
-	    /// <param name="templateRootFolder"></param>
-	    /// <returns></returns>
-	    public static FluentEmailServicesBuilder AddRazorRenderer(this FluentEmailServicesBuilder builder, string templateRootFolder)
+		/// <summary>
+		/// Add razor renderer with project views and layouts
+		/// </summary>
+		/// <param name="builder"></param>
+		/// <param name="templateRootFolder"></param>
+		/// <returns></returns>
+		public static FluentEmailServicesBuilder AddRazorRenderer(this FluentEmailServicesBuilder builder, string templateRootFolder)
         {
             builder.Services.TryAdd(ServiceDescriptor.Singleton<ITemplateRenderer, RazorRenderer>(sp => new RazorRenderer(templateRootFolder)));
             return builder;
@@ -49,5 +50,17 @@ namespace Microsoft.Extensions.DependencyInjection
 		    builder.Services.TryAdd(ServiceDescriptor.Singleton<ITemplateRenderer, RazorRenderer>(sp => new RazorRenderer(razorLightProject)));
 		    return builder;
 	    }
-    }
+
+		/// <summary>
+		/// Add razor renderer with project views and layouts
+		/// </summary>
+		/// <param name="builder"></param>
+		/// <param name="razorLightEngine"></param>
+		/// <returns></returns>
+		public static FluentEmailServicesBuilder AddRazorRenderer(this FluentEmailServicesBuilder builder, RazorLightEngine razorLightEngine)
+		{
+			builder.Services.TryAdd(ServiceDescriptor.Singleton<ITemplateRenderer, RazorRenderer>(sp => new RazorRenderer(razorLightEngine)));
+			return builder;
+		}
+	}
 }

--- a/src/Renderers/FluentEmail.Razor/RazorRenderer.cs
+++ b/src/Renderers/FluentEmail.Razor/RazorRenderer.cs
@@ -13,6 +13,11 @@ namespace FluentEmail.Razor
 	{
 		private readonly RazorLightEngine _engine;
 
+		public RazorRenderer(RazorLightEngine engine)
+		{
+			_engine = engine;
+		}
+
 		public RazorRenderer(string root = null)
 		{
 			_engine = new RazorLightEngineBuilder()


### PR DESCRIPTION
Today we provide a bunch of convenience methods to build out an engine, but we never allow the user to provide their own.

There are a lot of options being added to the RazorLightEngineBuilder and instead of trying to add an extension for every possible scenario, it will be helpful to allow the caller to provide their own.