### PR TITLE
Add support for SendGrid dynamic templates.

### DIFF
--- a/src/Senders/FluentEmail.SendGrid/IFluentEmailExtensions.cs
+++ b/src/Senders/FluentEmail.SendGrid/IFluentEmailExtensions.cs
@@ -1,0 +1,18 @@
+﻿using FluentEmail.Core;
+using FluentEmail.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FluentEmail.SendGrid
+{
+    public static class IFluentEmailExtensions
+    {
+        public static async Task<SendResponse> SendWithTemplateAsync(this IFluentEmail email, string templateId, object templateData)
+        {
+            var sendGridSender = email.Sender as ISendGridSender;
+            return await sendGridSender.SendWithTemplateAsync(email, templateId, templateData);
+        }
+    }
+}

--- a/src/Senders/FluentEmail.SendGrid/ISendGridSender.cs
+++ b/src/Senders/FluentEmail.SendGrid/ISendGridSender.cs
@@ -1,0 +1,27 @@
+﻿using FluentEmail.Core;
+using FluentEmail.Core.Interfaces;
+using FluentEmail.Core.Models;
+using SendGrid;
+using SendGrid.Helpers.Mail;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FluentEmail.SendGrid
+{
+    public interface ISendGridSender : ISender
+    {
+        /// <summary>
+        /// SendGrid specific extension method that allows you to use a template instead of a message body.
+        /// For more information, see: https://sendgrid.com/docs/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-templates/.
+        /// </summary>
+        /// <param name="email">Fluent email.</param>
+        /// <param name="templateId">SendGrid template ID.</param>
+        /// <param name="templateData">SendGrid template data.</param>
+        /// <param name="token">Optional cancellation token.</param>
+        /// <returns>A SendResponse object.</returns>
+        Task<SendResponse> SendWithTemplateAsync(IFluentEmail email, string templateId, object templateData, CancellationToken? token = null);
+    }
+}

--- a/src/Senders/FluentEmail.SendGrid/SendGridSender.cs
+++ b/src/Senders/FluentEmail.SendGrid/SendGridSender.cs
@@ -13,7 +13,7 @@ using SendGridAttachment = SendGrid.Helpers.Mail.Attachment;
 
 namespace FluentEmail.SendGrid
 {
-    public class SendGridSender : ISender
+    public class SendGridSender : ISendGridSender
     {
         private readonly string _apiKey;
         private readonly bool _sandBoxMode;
@@ -30,8 +30,41 @@ namespace FluentEmail.SendGrid
 
         public async Task<SendResponse> SendAsync(IFluentEmail email, CancellationToken? token = null)
         {
-            var sendGridClient = new SendGridClient(_apiKey);
+            var mailMessage = await BuildSendGridMessage(email);
 
+            if (email.Data.IsHtml)
+            {
+                mailMessage.HtmlContent = email.Data.Body;
+            }
+            else
+            {
+                mailMessage.PlainTextContent = email.Data.Body;
+            }
+
+            if (!string.IsNullOrEmpty(email.Data.PlaintextAlternativeBody))
+            {
+                mailMessage.PlainTextContent = email.Data.PlaintextAlternativeBody;
+            }
+
+            var sendResponse = await SendViaSendGrid(mailMessage, token);
+
+            return sendResponse;
+        }
+
+        public async Task<SendResponse> SendWithTemplateAsync(IFluentEmail email, string templateId, object templateData, CancellationToken? token = null)
+        {
+            var mailMessage = await BuildSendGridMessage(email);
+
+            mailMessage.SetTemplateId(templateId);
+            mailMessage.SetTemplateData(templateData);
+
+            var sendResponse = await SendViaSendGrid(mailMessage, token);
+
+            return sendResponse;
+        }
+
+        private async Task<SendGridMessage> BuildSendGridMessage(IFluentEmail email)
+        {
             var mailMessage = new SendGridMessage();
             mailMessage.SetSandBoxMode(_sandBoxMode);
 
@@ -55,15 +88,6 @@ namespace FluentEmail.SendGrid
             if (email.Data.Headers.Any())
             {
                 mailMessage.AddHeaders(email.Data.Headers.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
-            }
-
-            if (email.Data.IsHtml)
-            {
-                mailMessage.HtmlContent = email.Data.Body;
-            }
-            else
-            {
-                mailMessage.PlainTextContent = email.Data.Body;
             }
 
             switch (email.Data.Priority)
@@ -92,11 +116,6 @@ namespace FluentEmail.SendGrid
                     break;
             }
 
-            if (!string.IsNullOrEmpty(email.Data.PlaintextAlternativeBody))
-            {
-                mailMessage.PlainTextContent = email.Data.PlaintextAlternativeBody;
-            }
-
             if (email.Data.Attachments.Any())
             {
                 foreach (var attachment in email.Data.Attachments)
@@ -107,6 +126,12 @@ namespace FluentEmail.SendGrid
                 }
             }
 
+            return mailMessage;
+        }
+
+        private async Task<SendResponse> SendViaSendGrid(SendGridMessage mailMessage, CancellationToken? token = null)
+        {
+            var sendGridClient = new SendGridClient(_apiKey);
             var sendGridResponse = await sendGridClient.SendEmailAsync(mailMessage, token.GetValueOrDefault());
 
             var sendResponse = new SendResponse();

--- a/test/FluentEmail.Core.Tests/SendGridSenderTests.cs
+++ b/test/FluentEmail.Core.Tests/SendGridSenderTests.cs
@@ -43,6 +43,27 @@ namespace FluentEmail.SendGrid.Tests
         }
 
         [Test, Ignore("No sendgrid credentials")]
+        public async Task CanSendTemplateEmail()
+        {
+            const string subject = "SendMail Test";
+            const string templateId = "123456-insert-your-own-id-here";
+            object templateData = new
+            {
+                Name = toName,
+                ArbitraryValue = "The quick brown fox jumps over the lazy dog."
+            };
+
+            var email = Email
+                .From(fromEmail, fromName)
+                .To(toEmail, toName)
+                .Subject(subject);
+
+            var response = await email.SendWithTemplateAsync(templateId, templateData);
+
+            Assert.IsTrue(response.Successful);
+        }
+
+        [Test, Ignore("No sendgrid credentials")]
         public async Task CanSendEmailWithReplyTo()
         {
             const string subject = "SendMail Test";


### PR DESCRIPTION
This adds support for SendGrid's dynamic transactional templates (https://sendgrid.com/docs/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-templates/).

This was done by adding a new interface for the `SendGridSender` (`ISendGridSender`), which inherits from `ISender`. Using the extension method `IFluentEmail.SendWithTemplateAsync`, you can now send messages using a transactional template. This is done by supplying the template ID and optional dynamic template data.