### PR TITLE
Added support for Inline images for SmtpSender

### DIFF
--- a/src/Senders/FluentEmail.Smtp/SmtpSender.cs
+++ b/src/Senders/FluentEmail.Smtp/SmtpSender.cs
@@ -149,6 +149,7 @@ namespace FluentEmail.Smtp
                 System.Net.Mail.Attachment a = new System.Net.Mail.Attachment(x.Data, x.Filename, x.ContentType);
 
                 a.ContentId = x.ContentId;
+                a.ContentDisposition.Inline = x.IsInline;
 
                 message.Attachments.Add(a);
             });


### PR DESCRIPTION
Changed System.Net.Mime.ContentDisposition.Inline to match Core.Models.Attachment.IsInline.
Attachment's Content-Disposition header will be set to "inline" instead of "attachment" when attachment is marked inline, allowing it to be referenced by content-id when using SmtpSender.