### PR TITLE
fix SmtSender not passing CancellationToken to SmtpClient

### DIFF
--- a/src/Senders/FluentEmail.Smtp/SmtpSender.cs
+++ b/src/Senders/FluentEmail.Smtp/SmtpSender.cs
@@ -62,12 +62,12 @@ namespace FluentEmail.Smtp
             {
                 using (var client = _clientFactory())
                 {
-                    await client.SendMailExAsync(message);
+                    await client.SendMailExAsync(message, token ?? default);
                 }
             }
             else
             {
-                await _smtpClient.SendMailExAsync(message);
+                await _smtpClient.SendMailExAsync(message, token ?? default);
             }
 
             return response;
@@ -202,7 +202,10 @@ namespace FluentEmail.Smtp
             try
             {
                 client.SendAsync(message, tcs);
-                using (token.Register(() => client.SendAsyncCancel(), useSynchronizationContext: false))
+                using (token.Register(() =>
+                {
+                    client.SendAsyncCancel();
+                }, useSynchronizationContext: false))
                 {
                     await tcs.Task;
                 }


### PR DESCRIPTION
This will fix this [issue](https://github.com/lukencode/FluentEmail/issues/264)

I've tried to create test for cancelling token during `SmtpClient.SendAsync` but there is no way to do it. These tests are using `SmtpClient` with storing emails on the disk (`SmtpDeliveryMethod.SpecifiedPickupDirectory`). I've looked at impelementation of `SmtpClient` and no found any solution to stop executing (saving email to disk) & call `token.Cancel()`. 