### PR TITLE
Fix #229 add support for sendgrid categories 

### DIFF
--- a/src/FluentEmail.Core/Email.cs
+++ b/src/FluentEmail.Core/Email.cs
@@ -473,7 +473,7 @@ namespace FluentEmail.Core
         }
 
         /// <summary>
-        /// Adds tag to the Email. This is currently only supported by the Mailgun provider. <see href="https://documentation.mailgun.com/en/latest/user_manual.html#tagging"/>
+        /// Adds tag to the Email. This is currently only supported by the Mailgun and SendGrid providers. <see href="https://documentation.mailgun.com/en/latest/user_manual.html#tagging"/> and <see href="https://docs.sendgrid.com/for-developers/sending-email/categories"/>
         /// </summary>
         /// <param name="tag">Tag name, max 128 characters, ASCII only</param>
         /// <returns>Instance of the Email class</returns>

--- a/src/Senders/FluentEmail.SendGrid/SendGridSender.cs
+++ b/src/Senders/FluentEmail.SendGrid/SendGridSender.cs
@@ -57,6 +57,8 @@ namespace FluentEmail.SendGrid
                 mailMessage.AddHeaders(email.Data.Headers.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
             }
 
+            mailMessage.Categories.AddRange(email.Data.Tags);
+
             if (email.Data.IsHtml)
             {
                 mailMessage.HtmlContent = email.Data.Body;

--- a/test/FluentEmail.Core.Tests/SendGridSenderTests.cs
+++ b/test/FluentEmail.Core.Tests/SendGridSenderTests.cs
@@ -61,6 +61,25 @@ namespace FluentEmail.SendGrid.Tests
         }
 
         [Test, Ignore("No sendgrid credentials")]
+        public async Task CanSendEmailWithCategory()
+        {
+            const string subject = "SendMail Test";
+            const string body = "This email is testing send mail with Categories functionality of SendGrid Sender.";
+
+            var email = Email
+                .From(fromEmail, fromName)
+                .To(toEmail, toName)
+                .ReplyTo(toEmail, toName)
+                .Subject(subject)
+                .Tag("TestCategory")
+                .Body(body);
+
+            var response = await email.SendAsync();
+
+            Assert.IsTrue(response.Successful);
+        }
+
+        [Test, Ignore("No sendgrid credentials")]
         public async Task CanSendEmailWithAttachments()
         {
             const string subject = "SendMail With Attachments Test";


### PR DESCRIPTION
Implementation is using tags as those are similar concepts between mailgun and sendgrid.
Both have the same goal of tagging emails for statistics 

This fix #229