### PR TITLE
Update SendGrid nuget package dependency

### DIFF
--- a/src/Senders/FluentEmail.SendGrid/FluentEmail.SendGrid.csproj
+++ b/src/Senders/FluentEmail.SendGrid/FluentEmail.SendGrid.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Sendgrid" Version="9.26.0" />
+    <PackageReference Include="Sendgrid" Version="9.27.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Simple version bump to update to latest SendGrid nuget package [v9.27.0](https://github.com/sendgrid/sendgrid-csharp/releases/tag/9.27.0). 
