### PR TITLE
MessageId improvements for MailKitSender

### DIFF
--- a/src/Senders/FluentEmail.MailKit/MailKitSender.cs
+++ b/src/Senders/FluentEmail.MailKit/MailKitSender.cs
@@ -1,11 +1,13 @@
 ﻿using FluentEmail.Core;
 using FluentEmail.Core.Interfaces;
 using FluentEmail.Core.Models;
+using MailKit;
 using MailKit.Net.Smtp;
 using MimeKit;
 using System;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -17,6 +19,7 @@ namespace FluentEmail.MailKitSmtp
     public class MailKitSender : ISender
     {
         private readonly SmtpClientOptions _smtpClientOptions;
+        private readonly bool _isAmazonSes;
 
         /// <summary>
         /// Creates a sender that uses the given SmtpClientOptions when sending with MailKit. Since the client is internal this will dispose of the client.
@@ -25,6 +28,7 @@ namespace FluentEmail.MailKitSmtp
         public MailKitSender(SmtpClientOptions smtpClientOptions)
         {
             _smtpClientOptions = smtpClientOptions;
+            _isAmazonSes = smtpClientOptions.Server.EndsWith("amazonaws.com");
         }
 
         /// <summary>
@@ -35,8 +39,8 @@ namespace FluentEmail.MailKitSmtp
         /// <param name="token">Cancellation Token.</param>
         public SendResponse Send(IFluentEmail email, CancellationToken? token = null)
         {
-            var response = new SendResponse();
             var message = CreateMailMessage(email);
+            var response = new SendResponse() { MessageId = message.MessageId };
 
             if (token?.IsCancellationRequested ?? false)
             {
@@ -77,8 +81,23 @@ namespace FluentEmail.MailKitSmtp
                         client.Authenticate(_smtpClientOptions.User, _smtpClientOptions.Password, token.GetValueOrDefault());
                     }
 
+                    var mre = new ManualResetEventSlim(false);
+                    if (_isAmazonSes)
+                    {
+                        // If using Amazon SES, subscribe to the MessageSent event where we can retrieve the overwritten MessageId, then signal ManualResetEventSlim
+                        client.MessageSent += (s, e) => SmtpClient_MessageSent(s, e, mre);
+                    }
+                    else
+                    {
+                        // Otherwise signal ManualResetEventSlim right away
+                        mre.Set();
+                    }
+
                     client.Send(message, token.GetValueOrDefault());
                     client.Disconnect(true, token.GetValueOrDefault());
+
+                    // Block until ManualResetEventSlim is signaled
+                    mre.Wait();
                 }
             }
             catch (Exception ex)
@@ -97,8 +116,8 @@ namespace FluentEmail.MailKitSmtp
         /// <param name="token">Cancellation Token.</param>
         public async Task<SendResponse> SendAsync(IFluentEmail email, CancellationToken? token = null)
         {
-            var response = new SendResponse();
             var message = CreateMailMessage(email);
+            var response = new SendResponse() { MessageId = message.MessageId };
 
             if (token?.IsCancellationRequested ?? false)
             {
@@ -139,8 +158,23 @@ namespace FluentEmail.MailKitSmtp
                         await client.AuthenticateAsync(_smtpClientOptions.User, _smtpClientOptions.Password, token.GetValueOrDefault());
                     }
 
+                    var mre = new ManualResetEventSlim(false);
+                    if (_isAmazonSes)
+                    {
+                        // If using Amazon SES, subscribe to the MessageSent event where we can retrieve the overwritten MessageId, then signal ManualResetEventSlim
+                        client.MessageSent += (s, e) => SmtpClient_MessageSent(s, e, mre);
+                    }
+                    else
+                    {
+                        // Otherwise signal ManualResetEventSlim right away
+                        mre.Set();
+                    }
+
                     await client.SendAsync(message, token.GetValueOrDefault());
                     await client.DisconnectAsync(true, token.GetValueOrDefault());
+
+                    // Block until ManualResetEventSlim is signaled
+                    mre.Wait();
                 }
             }
             catch (Exception ex)
@@ -149,6 +183,22 @@ namespace FluentEmail.MailKitSmtp
             }
 
             return response;
+        }
+
+        private void SmtpClient_MessageSent(object sender, MessageSentEventArgs e, ManualResetEventSlim mre)
+        {
+            // Example response format: "Ok 010701805bea386d-8411ef2a-5a8b-46bc-9cbb-585ace484c24-000000"
+            var match = Regex.Match(e.Response, @"Ok ([0-9a-z\-]+)");
+            if (match.Success)
+            {
+                // Strip "email-smtp" and similar prefixes from SMTP hostname: https://docs.aws.amazon.com/general/latest/gr/ses.html
+                var domain = _smtpClientOptions.Server.Substring(_smtpClientOptions.Server.IndexOf('.') + 1);
+                var id = $"<{match.Groups[1].Value}@{domain}>";
+                e.Message.MessageId = id;
+            }
+
+            // Trigger ManualResetEventSlim to signal that the processing is now complete
+            mre.Set();
         }
 
         /// <summary>


### PR DESCRIPTION
This PR contains two changes regarding MailKitSender:
* Use local MessageId as SendResponse.MessageId
* Use remotely generated MessageId when using Amazon SES as SendResponse.MessageId

## Explanation
### Returning local MessageId as part of SendResponse
MailKit generates a local `Message-Id` for each message which is then passed to the remote SMTP service. Currently this field is not returned as part of `SendResponse`. This PR changes that.

### Amazon SES
While the header Message-Id should remain unchanged after its value is first set, Amazon's SES service overwrites it with its own value.

Knowing the value of this field is useful if someone wants to track whether a particular message has been accepted, bounced, complained about, etc.

This PR makes use of the `SmtpClient.MessageSent` event which fires after the message has been accepted. By using the hostname of the SMTP service and leveraging the `Response` property from the `MessageSentEventArgs` class we can determine the final value of Message-Id.

Since it cannot be guaranteed that the `MessageSent` event will fire before the `ISender.Send` or `ISender.SendAsync` method is returned, I've used an instance of `ManualResetEventSlim` to block the thread on `Wait()` until it is signaled. This signal is sent at the end of the MessageSent event (if the client is configured to use SES) or right away if SES is not used.

### References
> If you provide a Message-ID header, Amazon SES overrides the header with its own value.

Source: https://docs.aws.amazon.com/ses/latest/dg/header-fields.html

> If the request to Amazon SES succeeds, Amazon SES returns a success response to the sender. This message includes the message ID, a string of characters that uniquely identifies the request. You can use the message ID to identify the sent email or to track problems encountered during sending.

Source: https://docs.aws.amazon.com/ses/latest/dg/send-email-concepts-process.html