### PR TITLE
Make sure we set the content disposition on attachments for SendGrid

### DIFF
--- a/src/Senders/FluentEmail.SendGrid/SendGridSender.cs
+++ b/src/Senders/FluentEmail.SendGrid/SendGridSender.cs
@@ -181,7 +181,11 @@ namespace FluentEmail.SendGrid
         {
             Content = await GetAttachmentBase64String(attachment.Data),
             Filename = attachment.Filename,
-            Type = attachment.ContentType
+            Type = attachment.ContentType,
+            Disposition = attachment.IsInline
+                ? "inline"
+                : "attachment",
+            ContentId = attachment.ContentId
         };
 
         private async Task<string> GetAttachmentBase64String(Stream stream)


### PR DESCRIPTION
Currently, it is impossible to use inline attachments with SendGrid, because the SendGridSender ignores the `IsInline` & `ContentId` properties on attachments.

So, this simple change is to allow sending inline attachments with SendGrid