### PR TITLE
[MailKitSender] Per client ServerCertificateValidationCallback

### DIFF
--- a/src/Senders/FluentEmail.MailKit/MailKitSender.cs
+++ b/src/Senders/FluentEmail.MailKit/MailKitSender.cs
@@ -55,6 +55,7 @@ namespace FluentEmail.MailKitSmtp
 
                 using (var client = new SmtpClient())
                 {
+                    client.CheckCertificateRevocation = _smtpClientOptions.CheckCertificateRevocation;
                     if(_smtpClientOptions.ServerCertificateValidationCallback != null)
                     {
                         client.ServerCertificateValidationCallback = _smtpClientOptions.ServerCertificateValidationCallback;
@@ -122,6 +123,7 @@ namespace FluentEmail.MailKitSmtp
 
                 using (var client = new SmtpClient())
                 {
+                    client.CheckCertificateRevocation = _smtpClientOptions.CheckCertificateRevocation;
                     if (_smtpClientOptions.ServerCertificateValidationCallback != null)
                     {
                         client.ServerCertificateValidationCallback = _smtpClientOptions.ServerCertificateValidationCallback;

--- a/src/Senders/FluentEmail.MailKit/MailKitSender.cs
+++ b/src/Senders/FluentEmail.MailKit/MailKitSender.cs
@@ -5,6 +5,7 @@ using MailKit.Net.Smtp;
 using MimeKit;
 using System;
 using System.IO;
+using System.Net.Security;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -54,6 +55,11 @@ namespace FluentEmail.MailKitSmtp
 
                 using (var client = new SmtpClient())
                 {
+                    if(_smtpClientOptions.ServerCertificateValidationCallback is not null)
+                    {
+                        client.ServerCertificateValidationCallback = _smtpClientOptions.ServerCertificateValidationCallback;
+                    }
+
                     if (_smtpClientOptions.SocketOptions.HasValue)
                     {
                         client.Connect(
@@ -116,6 +122,11 @@ namespace FluentEmail.MailKitSmtp
 
                 using (var client = new SmtpClient())
                 {
+                    if (_smtpClientOptions.ServerCertificateValidationCallback is not null)
+                    {
+                        client.ServerCertificateValidationCallback = _smtpClientOptions.ServerCertificateValidationCallback;
+                    }
+
                     if (_smtpClientOptions.SocketOptions.HasValue)
                     {
                         await client.ConnectAsync(

--- a/src/Senders/FluentEmail.MailKit/MailKitSender.cs
+++ b/src/Senders/FluentEmail.MailKit/MailKitSender.cs
@@ -55,7 +55,7 @@ namespace FluentEmail.MailKitSmtp
 
                 using (var client = new SmtpClient())
                 {
-                    if(_smtpClientOptions.ServerCertificateValidationCallback is not null)
+                    if(_smtpClientOptions.ServerCertificateValidationCallback != null)
                     {
                         client.ServerCertificateValidationCallback = _smtpClientOptions.ServerCertificateValidationCallback;
                     }
@@ -122,7 +122,7 @@ namespace FluentEmail.MailKitSmtp
 
                 using (var client = new SmtpClient())
                 {
-                    if (_smtpClientOptions.ServerCertificateValidationCallback is not null)
+                    if (_smtpClientOptions.ServerCertificateValidationCallback != null)
                     {
                         client.ServerCertificateValidationCallback = _smtpClientOptions.ServerCertificateValidationCallback;
                     }

--- a/src/Senders/FluentEmail.MailKit/SmtpClientOptions.cs
+++ b/src/Senders/FluentEmail.MailKit/SmtpClientOptions.cs
@@ -15,6 +15,7 @@ namespace FluentEmail.MailKitSmtp
         public bool UsePickupDirectory { get; set; } = false;
         public string MailPickupDirectory { get; set; } = string.Empty;
         public SecureSocketOptions? SocketOptions { get; set; }
+        public bool CheckCertificateRevocation { get; set; } = true;
         public RemoteCertificateValidationCallback ServerCertificateValidationCallback { get; set; }
     }
 }

--- a/src/Senders/FluentEmail.MailKit/SmtpClientOptions.cs
+++ b/src/Senders/FluentEmail.MailKit/SmtpClientOptions.cs
@@ -1,4 +1,5 @@
 ﻿using MailKit.Security;
+using System.Net.Security;
 
 namespace FluentEmail.MailKitSmtp
 {
@@ -14,5 +15,6 @@ namespace FluentEmail.MailKitSmtp
         public bool UsePickupDirectory { get; set; } = false;
         public string MailPickupDirectory { get; set; } = string.Empty;
         public SecureSocketOptions? SocketOptions { get; set; }
+        public RemoteCertificateValidationCallback ServerCertificateValidationCallback { get; set; }
     }
 }


### PR DESCRIPTION
[FluentEmail.MailKit]
I added a new option in SmtpClientOptions to give the opportunity to specify a ServerCertificateValidationCallback per client.
If specified the callback is assigned to the MailKit SmtpClient and it will be used instead of the default one. In that way it is possible to avoid the use of the global variable "ServicePointManager.ServerCertificateValidationCallback"