### PR TITLE
Bind MailgunSender to ISender in singleton scope. 

### DIFF
--- a/src/Senders/FluentEmail.Mailgun/FluentEmailMailgunBuilderExtensions.cs
+++ b/src/Senders/FluentEmail.Mailgun/FluentEmailMailgunBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static FluentEmailServicesBuilder AddMailGunSender(this FluentEmailServicesBuilder builder, string domainName, string apiKey, MailGunRegion mailGunRegion = MailGunRegion.USA)
         {
-            builder.Services.TryAdd(ServiceDescriptor.Scoped<ISender>(_ => new MailgunSender(domainName, apiKey, mailGunRegion)));
+            builder.Services.TryAdd(ServiceDescriptor.Singleton<ISender>(_ => new MailgunSender(domainName, apiKey, mailGunRegion)));
             return builder;
         }
     }


### PR DESCRIPTION
Bind MailgunSender to ISender in singleton scope. 

MailgunSender creates a new HttpClient for each instance of a MailgunSender object. 

Based on Microsoft recommendations https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines#recommended-use I propose the MailgunSender should be bound in Singleton scope so that only one HttpClient is instantiated. 

