### PR TITLE
[BUG] Dispose of file stream in AttachFromFilename

### DIFF
--- a/src/FluentEmail.Core/Email.cs
+++ b/src/FluentEmail.Core/Email.cs
@@ -461,7 +461,7 @@ namespace FluentEmail.Core
 
         public IFluentEmail AttachFromFilename(string filename,  string contentType = null, string attachmentName = null)
         {
-            using var stream = File.OpenRead(filename);
+            var stream = new MemoryStream(File.ReadAllBytes(filename));
             Attach(new Attachment
             {
                 Data = stream,

--- a/src/FluentEmail.Core/Email.cs
+++ b/src/FluentEmail.Core/Email.cs
@@ -461,7 +461,7 @@ namespace FluentEmail.Core
 
         public IFluentEmail AttachFromFilename(string filename,  string contentType = null, string attachmentName = null)
         {
-            var stream = File.OpenRead(filename);
+            using var stream = File.OpenRead(filename);
             Attach(new Attachment
             {
                 Data = stream,


### PR DESCRIPTION
`Email.AttachFromFileName()` opens a stream on the source file but does not dispose of it. 